### PR TITLE
【功能】【低优先级】新增 `/llmlog` 斜杠命令，快捷打开 LLM API 日志窗口

### DIFF
--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -3824,6 +3824,9 @@
     "LLM API logs capture prompt/response bodies.": "LLM API 日志会记录提示词与模型回应（含 Raw JSON/SSE）。",
     "API recent keep must be a positive number": "API 最近日志保留条数必须为正数",
     "LLM API keep must be a positive number": "LLM API 日志保留条数必须为正数",
+    "LLM API logs are only available in TauriTavern.": "LLM API 日志仅在 TauriTavern 中可用。",
+    "Open the LLM API log viewer (TauriTavern only).": "打开 LLM API 日志查看器（仅限 TauriTavern）。",
+
     "Pause": "暂停",
     "Prev": "上一条",
     "Next": "下一条",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -4340,6 +4340,9 @@
     "LLM API logs capture prompt/response bodies.": "LLM API 日誌會記錄提示詞與模型回應（含 Raw JSON/SSE）。",
     "API recent keep must be a positive number": "API 最近日誌保留筆數必須為正數",
     "LLM API keep must be a positive number": "LLM API 日誌保留筆數必須為正數",
+    "LLM API logs are only available in TauriTavern.": "LLM API 日誌僅在 TauriTavern 中可用。",
+    "Open the LLM API log viewer (TauriTavern only).": "開啟 LLM API 日誌檢視器（僅限 TauriTavern）。",
+
     "Pause": "暫停",
     "Prev": "上一筆",
     "Next": "下一筆",

--- a/src/scripts/slash-commands.js
+++ b/src/scripts/slash-commands.js
@@ -3238,6 +3238,29 @@ export function initDefaultSlashCommands() {
         `,
     }));
 
+    // 新增 /llmlog 斜杠命令，快捷打开 LLM API 日志窗口（TauriTavern 专有功能）
+    // 无需进入设置面板即可直接打开日志查看器
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'llmlog',
+        aliases: ['apilog'],
+        callback: async () => {
+            // 检查 Tauri 宿主环境是否可用
+            if (!window.__TAURITAVERN__?.api?.dev) {
+                toastr.error(t`LLM API logs are only available in TauriTavern.`);
+                return '';
+            }
+            try {
+                const { openLlmApiLogsPanel } = await import('./tauri/setting/dev-logs.js');
+                await openLlmApiLogsPanel();
+            } catch (error) {
+                toastr.error(t`Failed to open LLM API logs: ${error?.message || error}`);
+            }
+            return '';
+        },
+        helpString: t`Open the LLM API log viewer (TauriTavern only).`,
+    }));
+
+
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'beep',
         aliases: ['ding'],


### PR DESCRIPTION
## 概述

这是一个便利性小更新，优先级不高。

在聊天输入框中新增 `/llmlog`（别名 `/apilog`）斜杠命令，可直接打开 LLM API 日志查看器。此前打开该窗口需要依次进入 **设置 → TauriTavern 设置 → 开发 → LLM API 日志**，路径较深，日常调试时不够顺手。

---

## 改动内容

| 文件 | 说明 |
|---|---|
| `src/scripts/slash-commands.js` | 在 `initDefaultSlashCommands()` 中注册 `/llmlog` 命令，动态导入 `openLlmApiLogsPanel()`；非 Tauri 宿主环境会以 toast 提示不可用 |
| `src/locales/zh-cn.json` | 添加简体中文翻译 |
| `src/locales/zh-tw.json` | 添加繁体中文翻译 |

- **命令名：** `/llmlog`（别名 `/apilog`）
- **行为：** 调用 `src/scripts/tauri/setting/dev-logs.js` 中的 `openLlmApiLogsPanel()`，与设置面板按钮触发的是同一个函数

---

## 使用方式

```
/llmlog
/apilog
```