### PR TITLE
feat: 允许 /trigger 斜杠命令触发 Agent 模式

### DIFF
--- a/src/scripts/slash-commands.js
+++ b/src/scripts/slash-commands.js
@@ -79,6 +79,7 @@ import { SlashCommandAbortController } from './slash-commands/SlashCommandAbortC
 import { SlashCommandNamedArgumentAssignment } from './slash-commands/SlashCommandNamedArgumentAssignment.js';
 import { SlashCommandEnumValue, enumTypes } from './slash-commands/SlashCommandEnumValue.js';
 import { getActiveIosPolicyCapabilities } from './tauritavern/ios-policy.js';
+import { getAgentGenerationOptions } from './tauritavern/agent/agent-generation-router.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
 import { SlashCommandBreakController } from './slash-commands/SlashCommandBreakController.js';
@@ -4502,7 +4503,14 @@ async function triggerGenerationCallback(args, value) {
             }
         }
 
-        outerResolve(new Promise(innerResolve => setTimeout(() => innerResolve(Generate('normal', { force_chid: chid })), 100)));
+        const agentOptions = await getAgentGenerationOptions({
+            generationType: 'normal',
+            isSlashCommand: false,
+            mainApi: main_api,
+            selectedGroup: selected_group,
+        }).catch(() => ({}));
+
+        outerResolve(new Promise(innerResolve => setTimeout(() => innerResolve(Generate('normal', { force_chid: chid, ...agentOptions })), 100)));
     }, 1));
 
     if (shouldAwait) {


### PR DESCRIPTION
## 概述
/trigger 斜杠命令现在可以触发 Agent 模式了。之前所有斜杠命令都被排除在
Agent 路由逻辑之外，导致依赖 triggerSlash('/trigger') 自动发送脚本的用户
无法使用 Agent 模式。

## 问题
sendTextareaMessage() 会检查输入是否以 / 开头（isSlashCommand），如果是
则跳过 Agent 选项。但 /trigger 命令内部直接调用 Generate()，不经过
sendTextareaMessage()，也没有检查 Agent 设置。

## 解决
在 triggerGenerationCallback() 中调用 getAgentGenerationOptions()，
显式传入 isSlashCommand: false，让 /trigger 可以正常走 Agent 路由。
同时完全尊重用户的 Agent 开关状态。

## 改动
src/scripts/slash-commands.js — 1 个文件，+9 -1 行

## 行为
| Agent 开关 | 操作 | 结果 |
|-----------|------|------|
| 关闭 | /trigger | 走 Legacy 生成（无变化） |
| 开启 | /trigger | 走 Agent 生成 |