### PR TITLE
feat(diagnostics): log upstream body preview when chat completion JSON parse fails + reclassify as transient

### DIFF
--- a/src-tauri/src/application/services/agent_runtime_service/error_payload.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/error_payload.rs
@@ -119,4 +119,19 @@ mod tests {
         assert_eq!(payload["message"], "upstream rate limit");
         assert_eq!(payload["retryable"], true);
     }
+
+    #[test]
+    fn upstream_invalid_response_is_transient_and_retryable() {
+        let payload = run_failure_payload(&ApplicationError::Transient(
+            "model.upstream_invalid_response: openai returned status 200 non-JSON body (generate): expected value at line 1 column 1"
+                .to_string(),
+        ));
+
+        assert_eq!(payload["code"], "model.upstream_invalid_response");
+        assert_eq!(
+            payload["message"],
+            "openai returned status 200 non-JSON body (generate): expected value at line 1 column 1"
+        );
+        assert_eq!(payload["retryable"], true);
+    }
 }

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/body_preview.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/body_preview.rs
@@ -1,0 +1,114 @@
+use std::fmt::Display;
+
+use reqwest::Response;
+use reqwest::StatusCode;
+use reqwest::header::CONTENT_TYPE;
+use serde_json::Value;
+
+use crate::domain::errors::DomainError;
+
+/// Maximum number of bytes from a non-JSON upstream body to capture in the
+/// diagnostic log. Anything larger is truncated; the full `body_len` is still
+/// emitted so log readers know how much was elided.
+pub(super) const BODY_PREVIEW_BYTES: usize = 512;
+
+/// Emit a structured `error!` event describing why a chat-completion upstream
+/// body could not be parsed as JSON. Always truncates the body to
+/// [`BODY_PREVIEW_BYTES`] so we don't blow up the log pipeline on huge HTML
+/// challenges, plain-text errors, or runaway bodies.
+pub(super) fn log_upstream_body_parse_failure(
+    provider_name: &str,
+    operation: &str,
+    status: StatusCode,
+    content_type: &str,
+    body: &[u8],
+    error: &impl Display,
+) {
+    let body_len = body.len();
+    let body_preview = body_preview_string(body);
+
+    tracing::error!(
+        provider = provider_name,
+        operation = operation,
+        status = status.as_u16(),
+        content_type = content_type,
+        body_len,
+        body_preview = %body_preview,
+        error = %error,
+        "upstream returned non-JSON body for chat completion",
+    );
+}
+
+/// Lossy UTF-8 preview of the first [`BODY_PREVIEW_BYTES`] of a body.
+pub(super) fn body_preview_string(body: &[u8]) -> String {
+    let preview_bytes = &body[..body.len().min(BODY_PREVIEW_BYTES)];
+    String::from_utf8_lossy(preview_bytes).into_owned()
+}
+
+/// Read an upstream HTTP response body and parse it as JSON, logging a
+/// detailed diagnostic event on failure. Caller is responsible for ensuring
+/// the response status was 2xx before invoking this helper.
+pub(super) async fn read_upstream_json_body(
+    provider_name: &str,
+    operation: &str,
+    response: Response,
+) -> Result<Value, DomainError> {
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let body = response.bytes().await.map_err(|error| {
+        DomainError::InternalError(format!(
+            "Failed to read {operation} body from {provider_name} (status {}): {error}",
+            status.as_u16()
+        ))
+    })?;
+
+    match serde_json::from_slice::<Value>(&body) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            log_upstream_body_parse_failure(
+                provider_name,
+                operation,
+                status,
+                &content_type,
+                &body,
+                &error,
+            );
+            Err(DomainError::InternalError(format!(
+                "Failed to parse {operation} JSON from {provider_name} (status {}): {error}",
+                status.as_u16()
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_preview_string_truncates_to_first_512_bytes() {
+        let body = vec![b'a'; BODY_PREVIEW_BYTES + 64];
+        let preview = body_preview_string(&body);
+        assert_eq!(preview.len(), BODY_PREVIEW_BYTES);
+        assert!(preview.chars().all(|character| character == 'a'));
+    }
+
+    #[test]
+    fn body_preview_string_returns_short_body_verbatim() {
+        let body = b"<html>error</html>";
+        assert_eq!(body_preview_string(body), "<html>error</html>");
+    }
+
+    #[test]
+    fn body_preview_string_replaces_invalid_utf8_lossily() {
+        let body = vec![0xff, 0xfe, b'O', b'K'];
+        let preview = body_preview_string(&body);
+        assert!(preview.contains("OK"));
+    }
+}

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/body_preview.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/body_preview.rs
@@ -48,6 +48,12 @@ pub(super) fn body_preview_string(body: &[u8]) -> String {
 /// Read an upstream HTTP response body and parse it as JSON, logging a
 /// detailed diagnostic event on failure. Caller is responsible for ensuring
 /// the response status was 2xx before invoking this helper.
+///
+/// Both body-read failures and JSON-decode failures are reported as
+/// [`DomainError::Transient`] tagged with `model.upstream_invalid_response`,
+/// because in practice they are caused by upstream-side hiccups (CDN
+/// challenges, proxy timeouts mid-body, plain-text 200 errors) that are worth
+/// retrying rather than tearing the run down as a fatal `agent.internal_error`.
 pub(super) async fn read_upstream_json_body(
     provider_name: &str,
     operation: &str,
@@ -62,8 +68,8 @@ pub(super) async fn read_upstream_json_body(
         .to_string();
 
     let body = response.bytes().await.map_err(|error| {
-        DomainError::InternalError(format!(
-            "Failed to read {operation} body from {provider_name} (status {}): {error}",
+        DomainError::transient(format!(
+            "model.upstream_invalid_response: {provider_name} returned status {} with unreadable body ({operation}): {error}",
             status.as_u16()
         ))
     })?;
@@ -79,8 +85,8 @@ pub(super) async fn read_upstream_json_body(
                 &body,
                 &error,
             );
-            Err(DomainError::InternalError(format!(
-                "Failed to parse {operation} JSON from {provider_name} (status {}): {error}",
+            Err(DomainError::transient(format!(
+                "model.upstream_invalid_response: {provider_name} returned status {} non-JSON body ({operation}): {error}",
                 status.as_u16()
             )))
         }

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/claude.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/claude.rs
@@ -11,6 +11,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 use super::normalizers;
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -47,9 +48,7 @@ pub(super) async fn list_models(
         .await);
     }
 
-    response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse models JSON: {error}"))
-    })
+    read_upstream_json_body("Claude", "list_models", response).await
 }
 
 pub(super) async fn generate(
@@ -91,9 +90,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body(provider_name, "generate", response).await?;
 
     if super::payload_contains_cache_control(payload) {
         let model = payload.get("model").and_then(Value::as_str);

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/cohere.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/cohere.rs
@@ -7,6 +7,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 
 pub(super) async fn list_models(
     repository: &HttpChatCompletionRepository,
@@ -32,9 +33,7 @@ pub(super) async fn list_models(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse models JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body("Cohere", "list_models", response).await?;
 
     Ok(json!({ "data": normalize_models(&body) }))
 }
@@ -71,9 +70,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })
+    read_upstream_json_body("Cohere", "generate", response).await
 }
 
 pub(super) async fn generate_stream(

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/gemini_interactions.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/gemini_interactions.rs
@@ -12,6 +12,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 use super::normalizers;
 
 const GEMINI_API_VERSION: &str = "v1beta";
@@ -387,9 +388,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body(provider_name, "generate", response).await?;
 
     Ok(normalizers::normalize_gemini_interactions_response(body))
 }

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/makersuite.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/makersuite.rs
@@ -8,6 +8,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 use super::normalizers;
 
 const GEMINI_API_VERSION: &str = "v1beta";
@@ -36,9 +37,7 @@ pub(super) async fn list_models(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse models JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body("Google Gemini", "list_models", response).await?;
 
     let models = body
         .get("models")
@@ -120,9 +119,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body("Google Gemini", "generate", response).await?;
 
     Ok(normalizers::normalize_gemini_response(body))
 }

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/mod.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/mod.rs
@@ -13,6 +13,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 use crate::infrastructure::http_client_pool::{HttpClientPool, HttpClientProfile};
 
+mod body_preview;
 mod claude;
 mod cohere;
 mod gemini_interactions;

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai.rs
@@ -7,6 +7,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 
 pub(super) async fn list_models(
     repository: &HttpChatCompletionRepository,
@@ -42,9 +43,7 @@ pub(super) async fn list_models_with_path(
         .await);
     }
 
-    response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse models JSON: {error}"))
-    })
+    read_upstream_json_body(provider_name, "list_models", response).await
 }
 
 pub(super) async fn generate(
@@ -79,9 +78,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body(provider_name, "generate", response).await?;
 
     if super::payload_contains_cache_control(payload) {
         let model = payload.get("model").and_then(Value::as_str);

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai_responses.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai_responses.rs
@@ -19,6 +19,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::{log_upstream_body_parse_failure, read_upstream_json_body};
 use super::normalizers;
 
 type ResponsesWsStream = tokio_tungstenite::WebSocketStream<reqwest::Upgraded>;
@@ -463,9 +464,7 @@ async fn generate_http(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body(provider_name, "generate", response).await?;
 
     Ok(normalizers::normalize_openai_responses_response(body))
 }
@@ -1090,6 +1089,14 @@ fn response_from_ws_payload(payload: &[u8]) -> Result<Option<Value>, DomainError
 
 fn parse_ws_event(payload: &[u8]) -> Result<Value, DomainError> {
     serde_json::from_slice(payload).map_err(|error| {
+        log_upstream_body_parse_failure(
+            "OpenAI Responses",
+            "generate_stream_ws",
+            StatusCode::SWITCHING_PROTOCOLS,
+            "application/json",
+            payload,
+            &error,
+        );
         DomainError::InternalError(format!(
             "OpenAI Responses WebSocket event is not valid JSON: {error}"
         ))

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai_responses.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/openai_responses.rs
@@ -1097,8 +1097,8 @@ fn parse_ws_event(payload: &[u8]) -> Result<Value, DomainError> {
             payload,
             &error,
         );
-        DomainError::InternalError(format!(
-            "OpenAI Responses WebSocket event is not valid JSON: {error}"
+        DomainError::transient(format!(
+            "model.upstream_invalid_response: OpenAI Responses WebSocket event is not valid JSON: {error}"
         ))
     })
 }

--- a/src-tauri/src/infrastructure/apis/http_chat_completion_repository/vertexai.rs
+++ b/src-tauri/src/infrastructure/apis/http_chat_completion_repository/vertexai.rs
@@ -8,6 +8,7 @@ use crate::domain::repositories::chat_completion_repository::{
 };
 
 use super::HttpChatCompletionRepository;
+use super::body_preview::read_upstream_json_body;
 use super::normalizers;
 
 const PROVIDER_NAME: &str = "Google Vertex AI";
@@ -73,9 +74,7 @@ pub(super) async fn generate(
         .await);
     }
 
-    let body = response.json::<Value>().await.map_err(|error| {
-        DomainError::InternalError(format!("Failed to parse generation JSON: {error}"))
-    })?;
+    let body = read_upstream_json_body(PROVIDER_NAME, "generate", response).await?;
 
     Ok(normalizers::normalize_gemini_response(body))
 }


### PR DESCRIPTION
## 背景

当上游 LLM provider 返回 HTTP 2xx 但 body 不是合法 JSON / SSE（CDN 拦截返回 HTML challenge、proxy 超时返回空体、上游返回 plain-text 错误、SSE 配置错落到非流式 path 等），目前后端：

1. 直接以 `DomainError::InternalError("Failed to parse generation JSON: ...")` 失败
2. 在 agent runtime 被分类为 `agent.internal_error` + `retryable=false` → 用户看到的是"内部错误，不可重试"
3. **没有任何 ERROR log**，body 内容被丢弃，无法追查 upstream 实际回了什么

实际上这是典型的 **transient upstream 异常**，应该 retryable=true，且应该保留诊断信息。

## Summary

- **A. 诊断可观察性**：抽取共享 helper `body_preview.rs`，覆盖 7 个 provider 的 12 个 JSON 解析失败点（list_models + generate + Realtime WS event），失败时 `tracing::error!` 结构化记录 provider / operation / status / content_type / body_len / body_preview（前 512 字节 UTF-8 lossy）。永久 diagnostics，不是临时 debug。
- **B. 错误分类修复**：所有 upstream JSON 解析失败 / body 读取失败的路径，从 `DomainError::InternalError` 改成 `DomainError::Transient("model.upstream_invalid_response: ...")`。冒泡到 `error_payload::run_failure_payload` 后自动 `retryable=true`，前端可以正确触发自动重试。
- **不新增 `DomainError` 变体**：复用现有 `Transient`，因此 `From<DomainError>` 的 3 处 match arm（application / presentation / lan_sync）**完全未触碰**——遵守 SKILL.md 的"smallest blast radius"准则。
- **错误码**：`model.upstream_invalid_response`，与 `error_payload::is_error_code` 校验相符，对齐现有 `model.*` 命名风格（`model.tool_call_required` / `model.provider_rate_limited`）。

## Commits

- `fdc2cea` feat(diagnostics): log upstream body preview when chat completion JSON parse fails
- `9911397` fix(agent): reclassify upstream invalid response as transient retryable

## 改动范围

9 个文件：

- 新建 `infrastructure/apis/http_chat_completion_repository/body_preview.rs`（helper）
- `mod.rs` 注册
- 7 个 provider 文件改调用点（openai / claude / cohere / makersuite / gemini_interactions / vertexai / openai_responses）
- `agent_runtime_service/error_payload.rs` 增 1 个单元测试

## SSE / WS 路径说明

7 个 provider 的 SSE 路径里现存的 `serde_json::from_slice` 大多是 telemetry-only 静默忽略（cache 性能日志、`let Ok(value) = … else { return; };`），属于"事件不匹配预期 shape 时跳过"，不是 fail-loud 路径，**不**应该灌 ERROR 日志。SSE 真正会冒泡的失败只有 mod.rs 的 UTF-8 校验和 chunk 读失败，已经各自分类合理，不在本 PR 范围。`openai_responses` 的 WS 路径 `parse_ws_event` 是唯一会冒泡的 JSON 解析点，已纳入 helper。

## 验证

- `cargo check --tests` 在 `chore/upstream-body-diagnostics` 上绿。
- 新加单元测试 `upstream_invalid_response_is_transient_and_retryable` 断言 code/message/retryable 三个字段。

## Test plan

- [ ] 配置一个会返回 HTML 错误页或空体的 endpoint（或 mitmproxy 拦截 OpenAI compatible 请求重写 body），触发一次 chat completion
- [ ] 确认 backend ERROR 日志里能看到完整的 `provider`/`operation`/`status`/`content_type`/`body_preview` 字段
- [ ] 确认 `run_failed` payload 的 `code === "model.upstream_invalid_response"`、`retryable === true`
- [ ] 现有 LLM provider 走正常 JSON 响应时无任何 ERROR 日志（不是误报）

## 设计权衡

- **没有在本 PR 引入 `userRetryable` 字段**：B 这边初始基于干净的 `origin/next/2.0.0`，没看到另一个分支 `fix/issues-54-55` 上的后端 commit `fb23853` 已经加了 `userRetryable`。一旦 #54/#55 PR 合并，`retryable=true` 也会让 `userRetryable=true`，UI 自动可手动 Retry，因此本 PR 不需要重复造该字段。
- **不动 `DomainError` 变体**：避免 `From<DomainError>` 三处 match 同步改动，PR 体量保持最小。

Made with [Cursor](https://cursor.com)