### PR TITLE
fix(agent): translate directory access to recoverable error (#54) + emit run_rollback_targets on instruction drift (#55) [backend]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
+.cursor/
 .DS_Store
 *.suo
 *.ntvs*

--- a/docs/Agent/RunEventJournal.md
+++ b/docs/Agent/RunEventJournal.md
@@ -140,6 +140,7 @@ run_committed
 run_completed
 run_cancel_requested
 run_cancelled
+run_rollback_targets
 run_failed
 ```
 
@@ -153,6 +154,7 @@ status_changed
 run_completed
 run_cancel_requested
 run_cancelled
+run_rollback_targets
 run_failed
 ```
 
@@ -162,8 +164,31 @@ run_failed
 {
   "code": "tool_policy_denied",
   "message": "Tool mcp.foo is not allowed by current plan node",
+  "technicalMessage": "Validation error: tool_policy_denied: ...",
   "retryable": false,
+  "userRetryable": false,
   "details": {}
+}
+```
+
+- `retryable`：宿主可不询问用户、安全地自动重试。仅在 `RateLimited`/`Transient` 等暂态错误上为 `true`。
+- `userRetryable`：用户可通过 UI 手动重试（前置已 rollback 漂移产物）。`retryable=true` 时一定为 `true`；此外 `model.tool_call_required`、`agent.tool_after_finish`、`agent.max_tool_rounds_exceeded` 等指令漂移类错误也是 `userRetryable=true`，但 **禁止** 自动重试。
+
+当一次 run 因为指令漂移失败、并且该 run 已经通过 `workspace.commit` 向 chat 发布过消息时，loop runner 会在 `run_failed` **之前**额外写一条 `run_rollback_targets` 事件，列出本次 run 留下的"漂移产物"，宿主 UI 应据此回滚这些消息再向用户暴露 Retry：
+
+```json
+{
+  "reasonCode": "model.tool_call_required",
+  "round": 5,
+  "targetCount": 1,
+  "targets": [
+    {
+      "path": "output/main.md",
+      "mode": "replace",
+      "messageId": "10",
+      "round": 4
+    }
+  ]
 }
 ```
 
@@ -486,6 +511,7 @@ run_committed
 run_completed
 run_cancel_requested
 run_cancelled
+run_rollback_targets
 run_failed
 ```
 

--- a/docs/Agent/ToolSystem.md
+++ b/docs/Agent/ToolSystem.md
@@ -190,7 +190,9 @@ persist/
 
 工具参数会写入 `tool-args/call_<sha256_8byte_hex(call-id)>.json`，工具结果会写入 `tool-results/call_<sha256_8byte_hex(call-id)>.json`；本地文件名只使用 SHA-256 前 8 字节 hex。provider 返回的原始 `call_id` 只作为不透明业务 ID 保存在 JSON 内容、journal payload 与下一轮 canonical `ToolResult` part 中，不作为本地文件名。Gateway 会在 provider 边界把它转换为对应 provider 格式。工具结果不会写入 SillyTavern chat 楼层。
 
-`workspace.apply_patch` 使用 Claude Code 风格的 `old_string` / `new_string` 单文件精确替换。未完整读取、版本变化、匹配 0 次或多次会作为 recoverable tool error 返回模型。模型传入的非法 path、空 path、不可见/不可写 path 也作为可恢复工具错误回填；repository 内部 escape/symlink/IO、journal、checkpoint、序列化、取消和模型响应结构错误仍 fail-fast。
+`workspace.apply_patch` 使用 Claude Code 风格的 `old_string` / `new_string` 单文件精确替换。未完整读取、版本变化、匹配 0 次或多次会作为 recoverable tool error 返回模型。模型传入的非法 path、空 path、不可见/不可写 path 也作为可恢复工具错误回填；目标 path 实际指向目录的读写请求会作为 `workspace.path_is_directory` 业务错误回填，提示模型改用 `workspace_list_files`。repository 内部 escape/symlink/journal、checkpoint、序列化、取消和模型响应结构错误仍 fail-fast。
+
+`workspace.commit` 与 `workspace.finish` 的契约：模型必须在最后一次 commit 之后的同一回合或紧随其后调用 `workspace.finish`，**不允许**在 commit 后回纯文本。违反此契约（包括 `model.tool_call_required` / `agent.tool_after_finish` / `agent.max_tool_rounds_exceeded`）属于 instruction drift，run 会以 `userRetryable=true` 失败，并通过 `run_rollback_targets` 事件给出本次 run 已 commit 的 message 列表供宿主 UI 回滚；细节见 `RunEventJournal.md`。
 
 当前没有 MCP、shell、extension bridge、profile routing、Plan Mode runtime 或审批工具。
 

--- a/src-tauri/src/application/errors.rs
+++ b/src-tauri/src/application/errors.rs
@@ -39,6 +39,7 @@ impl From<DomainError> for ApplicationError {
             DomainError::InternalError(msg) => ApplicationError::InternalError(msg),
             DomainError::RateLimited { message } => ApplicationError::RateLimited(message),
             DomainError::Transient(msg) => ApplicationError::Transient(msg),
+            DomainError::Conflict(msg) => ApplicationError::ValidationError(msg),
         }
     }
 }

--- a/src-tauri/src/application/services/agent_runtime_service/commit.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/commit.rs
@@ -7,7 +7,9 @@ use super::{
 };
 use crate::application::dto::agent_dto::AgentResolveChatCommitDto;
 use crate::application::errors::ApplicationError;
-use crate::application::services::agent_tools::{AgentToolDispatchOutcome, AgentToolEffect};
+use crate::application::services::agent_tools::{
+    AgentToolDispatchOutcome, AgentToolEffect, parse_workspace_conflict_message,
+};
 use crate::domain::errors::DomainError;
 use crate::domain::models::agent::{
     AgentChatCommitMode, AgentRunEventLevel, AgentRunStatus, AgentToolCall, AgentToolResult,
@@ -76,6 +78,10 @@ impl AgentRuntimeService {
                     &message,
                     elapsed_ms,
                 ));
+            }
+            Err(DomainError::Conflict(message)) => {
+                let (code, detail) = parse_workspace_conflict_message(&message);
+                return Ok(recoverable_tool_error(call, code, detail, elapsed_ms));
             }
             Err(error) => return Err(error.into()),
         };

--- a/src-tauri/src/application/services/agent_runtime_service/error_payload.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/error_payload.rs
@@ -2,14 +2,26 @@ use serde_json::{Value, json};
 
 use crate::application::errors::ApplicationError;
 
+/// Drift-class codes that should _never_ be auto-retried (the model
+/// disobeyed the tool contract), but the user is allowed to manually retry
+/// the same turn after the orphaned commits are rolled back. See issue #55.
+const USER_RETRYABLE_DRIFT_CODES: &[&str] = &[
+    "model.tool_call_required",
+    "agent.tool_after_finish",
+    "agent.max_tool_rounds_exceeded",
+];
+
 pub(super) fn run_failure_payload(error: &ApplicationError) -> Value {
     let (code, message) = agent_error_code_and_message(error);
+    let retryable = is_retryable(error);
+    let user_retryable = retryable || USER_RETRYABLE_DRIFT_CODES.contains(&code.as_str());
 
     json!({
         "code": code,
         "message": message,
         "technicalMessage": error.to_string(),
-        "retryable": is_retryable(error),
+        "retryable": retryable,
+        "userRetryable": user_retryable,
         "details": {},
     })
 }
@@ -91,6 +103,9 @@ mod tests {
             "Validation error: model.tool_call_required: model must use Agent tools and finish through workspace_finish"
         );
         assert_eq!(payload["retryable"], false);
+        // Issue #55: drift errors must offer a manual Retry path even
+        // though automatic retry is disabled.
+        assert_eq!(payload["userRetryable"], true);
         assert_eq!(payload["details"], json!({}));
     }
 
@@ -107,6 +122,9 @@ mod tests {
             "Permission denied: workspace root is hidden"
         );
         assert_eq!(payload["retryable"], false);
+        // Non-drift, non-retryable errors stay non-user-retryable so the
+        // UI does not lure the user into clicking Retry on policy errors.
+        assert_eq!(payload["userRetryable"], false);
     }
 
     #[test]
@@ -118,5 +136,31 @@ mod tests {
         assert_eq!(payload["code"], "model.provider_rate_limited");
         assert_eq!(payload["message"], "upstream rate limit");
         assert_eq!(payload["retryable"], true);
+        // Auto-retryable errors are user-retryable by definition.
+        assert_eq!(payload["userRetryable"], true);
+    }
+
+    #[test]
+    fn tool_after_finish_drift_is_user_retryable() {
+        let payload = run_failure_payload(&ApplicationError::ValidationError(
+            "agent.tool_after_finish: model requested additional tools after workspace.finish"
+                .to_string(),
+        ));
+
+        assert_eq!(payload["code"], "agent.tool_after_finish");
+        assert_eq!(payload["retryable"], false);
+        assert_eq!(payload["userRetryable"], true);
+    }
+
+    #[test]
+    fn max_tool_rounds_exceeded_is_user_retryable() {
+        let payload = run_failure_payload(&ApplicationError::ValidationError(
+            "agent.max_tool_rounds_exceeded: workspace.finish was not called within 12 rounds"
+                .to_string(),
+        ));
+
+        assert_eq!(payload["code"], "agent.max_tool_rounds_exceeded");
+        assert_eq!(payload["retryable"], false);
+        assert_eq!(payload["userRetryable"], true);
     }
 }

--- a/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
@@ -1,4 +1,4 @@
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::model_turn::{
     append_tool_turn_to_request, assistant_message_for_next_turn, extract_response_text,
@@ -10,8 +10,21 @@ use crate::application::errors::ApplicationError;
 use crate::application::services::agent_tools::{AgentToolEffect, AgentToolSession};
 use crate::domain::models::agent::profile::ResolvedAgentProfile;
 use crate::domain::models::agent::{
-    AgentModelRequest, AgentRunEventLevel, AgentRunStatus, AgentToolResult, WorkspacePath,
+    AgentChatCommitMode, AgentModelRequest, AgentRunEventLevel, AgentRunStatus, AgentToolResult,
+    WorkspacePath,
 };
+
+/// Tracks a chat commit that the model produced during this run. When the
+/// run later fails because of instruction drift (issue #55), we surface
+/// these records on a `run_rollback_targets` event so the host UI can offer
+/// the user a clean Retry that discards the drift artifacts.
+#[derive(Debug, Clone)]
+struct CommittedChatMessage {
+    path: String,
+    mode: AgentChatCommitMode,
+    message_id: Option<String>,
+    round: usize,
+}
 
 impl AgentRuntimeService {
     pub(super) async fn run_tool_loop(
@@ -23,6 +36,7 @@ impl AgentRuntimeService {
     ) -> Result<Option<usize>, ApplicationError> {
         let mut tool_session = AgentToolSession::default();
         let mut commit_count = 0_usize;
+        let mut committed_messages: Vec<CommittedChatMessage> = Vec::new();
         for round in 1..=profile.tools.max_rounds {
             self.transition_status(run_id, AgentRunStatus::CallingModel)
                 .await?;
@@ -82,6 +96,8 @@ impl AgentRuntimeService {
             .await?;
 
             if tool_calls.is_empty() {
+                self.emit_run_rollback_targets(run_id, &committed_messages, "model.tool_call_required", round)
+                    .await?;
                 return Err(ApplicationError::ValidationError(
                     "model.tool_call_required: model must use Agent tools and finish through workspace_finish"
                         .to_string(),
@@ -94,6 +110,13 @@ impl AgentRuntimeService {
 
             for call in tool_calls {
                 if finished {
+                    self.emit_run_rollback_targets(
+                        run_id,
+                        &committed_messages,
+                        "agent.tool_after_finish",
+                        round,
+                    )
+                    .await?;
                     return Err(ApplicationError::ValidationError(
                         "agent.tool_after_finish: model requested additional tools after workspace.finish".to_string(),
                     ));
@@ -154,6 +177,12 @@ impl AgentRuntimeService {
                         message_id,
                     } => {
                         commit_count += 1;
+                        committed_messages.push(CommittedChatMessage {
+                            path: path.as_str().to_string(),
+                            mode: *mode,
+                            message_id: message_id.clone(),
+                            round,
+                        });
                         self.event(
                             run_id,
                             AgentRunEventLevel::Info,
@@ -195,7 +224,55 @@ impl AgentRuntimeService {
             self.ensure_not_cancelled(cancel)?;
         }
 
+        // We ran out of rounds before workspace_finish was called. Any
+        // commits made along the way are now orphaned — surface them so the
+        // host can offer a clean Retry that rolls them back.
+        self.emit_run_rollback_targets(
+            run_id,
+            &committed_messages,
+            "agent.max_tool_rounds_exceeded",
+            profile.tools.max_rounds,
+        )
+        .await?;
+
         Ok(None)
+    }
+
+    async fn emit_run_rollback_targets(
+        &self,
+        run_id: &str,
+        committed_messages: &[CommittedChatMessage],
+        reason_code: &str,
+        round: usize,
+    ) -> Result<(), ApplicationError> {
+        if committed_messages.is_empty() {
+            return Ok(());
+        }
+
+        let targets = committed_messages
+            .iter()
+            .map(|message| {
+                json!({
+                    "path": message.path,
+                    "mode": message.mode,
+                    "messageId": message.message_id.as_deref(),
+                    "round": message.round,
+                })
+            })
+            .collect::<Vec<_>>();
+        self.event(
+            run_id,
+            AgentRunEventLevel::Warn,
+            "run_rollback_targets",
+            json!({
+                "reasonCode": reason_code,
+                "round": round,
+                "targetCount": targets.len(),
+                "targets": Value::Array(targets),
+            }),
+        )
+        .await?;
+        Ok(())
     }
 
     async fn hydrate_recent_tool_results_for_model(

--- a/src-tauri/src/application/services/agent_runtime_service/tests.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/tests.rs
@@ -1126,6 +1126,157 @@ async fn foreground_run_commits_chat_message_before_finish() {
     tokio::fs::remove_dir_all(root).await.expect("cleanup");
 }
 
+/// Issue #55: when the model commits, then drifts by replying with plain
+/// text (no tool calls) in the next round, the run must fail AND emit a
+/// `run_rollback_targets` event listing the now-orphaned chat message so
+/// the host UI can roll it back and offer the user a clean Retry.
+#[tokio::test]
+async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
+    let root = std::env::temp_dir().join(format!(
+        "tauritavern-agent-drift-rollback-{}",
+        Uuid::new_v4().simple()
+    ));
+    let repository = Arc::new(FileAgentRepository::new(root.clone()));
+    let run = AgentRun {
+        id: "run_drift_rollback_test".to_string(),
+        workspace_id: "chat_drift_rollback_test".to_string(),
+        stable_chat_id: "stable_drift_rollback_test".to_string(),
+        chat_ref: AgentChatRef::Character {
+            character_id: "Seraphina".to_string(),
+            file_name: "Seraphina.png".to_string(),
+        },
+        generation_type: "normal".to_string(),
+        profile_id: None,
+        persist_base_state_id: None,
+        presentation: AgentRunPresentation::Foreground,
+        status: AgentRunStatus::Created,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    repository.create_run(&run).await.expect("create run");
+
+    let model_gateway = Arc::new(MockAgentModelGateway::new(vec![
+        // Round 1: legitimately write the artifact.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_write_drift",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_write_file",
+                            "arguments": "{\"path\":\"output/main.md\",\"content\":\"drift answer\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 2: commit the artifact (this is the moment that publishes
+        // the chat message we need to roll back later).
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_commit_drift",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_commit",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 3: drift — return plain text and no tool calls. This is
+        // the failure mode the issue describes.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Sorry, here is the full answer one more time...",
+                }
+            }]
+        }),
+    ]));
+
+    let service = Arc::new(AgentRuntimeService::new(
+        repository.clone(),
+        repository.clone(),
+        repository.clone(),
+        test_chat_repository(&root),
+        test_chat_repository(&root),
+        test_skill_service(&root),
+        model_gateway,
+        test_profile_service(&root),
+    ));
+    let request = ChatCompletionGenerateRequestDto {
+        payload: json!({
+            "chat_completion_source": "openai",
+            "model": "test-model",
+            "messages": prompt_messages("drift after commit")
+        })
+        .as_object()
+        .cloned()
+        .unwrap(),
+    };
+    let prompt_snapshot = json!({ "chatCompletionPayload": request.payload.clone() });
+    let (_cancel_sender, mut cancel_receiver) = watch::channel(false);
+    let mut profile = test_resolved_profile(&root).await;
+    profile.run.presentation = AgentRunPresentation::Foreground;
+
+    let resolver = tokio::spawn(resolve_next_chat_commit(
+        service.clone(),
+        repository.clone(),
+        run.id.clone(),
+        "message_42",
+    ));
+    let outcome = service
+        .execute_agent_loop_run_inner(
+            &run.id,
+            prompt_snapshot,
+            request,
+            profile,
+            &mut cancel_receiver,
+        )
+        .await;
+    resolver.await.expect("resolver task");
+
+    assert!(
+        outcome.is_err(),
+        "drift after commit must fail the run, got Ok"
+    );
+
+    let events = repository
+        .read_events(
+            &run.id,
+            AgentRunEventReadQuery {
+                after_seq: Some(0),
+                before_seq: None,
+                limit: 200,
+            },
+        )
+        .await
+        .expect("read events");
+
+    let rollback = events
+        .iter()
+        .find(|event| event.event_type == "run_rollback_targets")
+        .expect("run_rollback_targets event must be emitted on drift after commit");
+    assert_eq!(rollback.level, AgentRunEventLevel::Warn);
+    assert_eq!(rollback.payload["reasonCode"], "model.tool_call_required");
+    assert_eq!(rollback.payload["targetCount"], 1);
+    let targets = rollback.payload["targets"]
+        .as_array()
+        .expect("targets array");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0]["messageId"], "message_42");
+    assert_eq!(targets[0]["path"], "output/main.md");
+}
+
 #[tokio::test]
 async fn foreground_finish_before_commit_returns_recoverable_error() {
     let root = std::env::temp_dir().join(format!(

--- a/src-tauri/src/application/services/agent_tools.rs
+++ b/src-tauri/src/application/services/agent_tools.rs
@@ -10,3 +10,5 @@ mod world_info;
 pub use dispatcher::{AgentToolDispatchOutcome, AgentToolDispatcher, AgentToolEffect};
 pub use registry::BuiltinAgentToolRegistry;
 pub use session::AgentToolSession;
+
+pub(crate) use common::parse_workspace_conflict_message;

--- a/src-tauri/src/application/services/agent_tools/common.rs
+++ b/src-tauri/src/application/services/agent_tools/common.rs
@@ -51,6 +51,24 @@ pub(super) fn optional_bool_arg(
         .ok_or_else(|| format!("{key} must be a boolean"))
 }
 
+/// Decode a `DomainError::Conflict` payload raised by the workspace
+/// repository into a `(code, detail)` pair suitable for a model-facing
+/// `AgentToolResult`. Today the only conflict we raise is
+/// `workspace.path_is_directory`, but new prefixes can be added here without
+/// touching every tool entry point.
+///
+/// Visibility is `pub(crate)` so that both the workspace tool layer
+/// (`workspace/args.rs`) and the runtime-service commit hook
+/// (`agent_runtime_service/commit.rs`) share a single parsing source of
+/// truth.
+pub(crate) fn parse_workspace_conflict_message(message: &str) -> (&'static str, &str) {
+    let trimmed = message.trim();
+    if let Some(rest) = trimmed.strip_prefix("workspace.path_is_directory:") {
+        return ("workspace.path_is_directory", rest.trim_start());
+    }
+    ("workspace.invalid_state", trimmed)
+}
+
 pub(super) fn tool_error(call: &AgentToolCall, error_code: &str, message: &str) -> AgentToolResult {
     AgentToolResult {
         call_id: call.id.clone(),

--- a/src-tauri/src/application/services/agent_tools/workspace/apply_patch.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/apply_patch.rs
@@ -1,12 +1,11 @@
 use serde_json::json;
 
 use super::args::{
-    ensure_writable_workspace_path, object_args, optional_bool_arg, parse_workspace_path,
-    required_raw_string_arg, required_trimmed_string_arg, tool_error,
+    classify_workspace_io_error, ensure_writable_workspace_path, object_args, optional_bool_arg,
+    parse_workspace_path, required_raw_string_arg, required_trimmed_string_arg, tool_error,
 };
 use super::policy::workspace_access_policy;
 use crate::application::errors::ApplicationError;
-use crate::domain::errors::DomainError;
 use crate::domain::models::agent::{AgentToolCall, AgentToolResult};
 use crate::domain::repositories::workspace_repository::WorkspaceRepository;
 
@@ -110,13 +109,10 @@ pub(in crate::application::services::agent_tools) async fn apply_patch(
 
     let file = match workspace_repository.read_text(run_id, &path).await {
         Ok(file) => file,
-        Err(DomainError::NotFound(message)) => {
-            return Ok((
-                tool_error(call, "workspace.file_not_found", &message),
-                AgentToolEffect::None,
-            ));
-        }
-        Err(error) => return Err(error.into()),
+        Err(error) => match classify_workspace_io_error(call, error) {
+            Ok(result) => return Ok((result, AgentToolEffect::None)),
+            Err(error) => return Err(error.into()),
+        },
     };
     if file.sha256 != read_state.sha256 {
         return Ok((
@@ -162,9 +158,13 @@ pub(in crate::application::services::agent_tools) async fn apply_patch(
         file.text.replacen(old_string, new_string, 1)
     };
     let old_sha256 = file.sha256.clone();
-    let file = workspace_repository
-        .write_text(run_id, &path, &updated)
-        .await?;
+    let file = match workspace_repository.write_text(run_id, &path, &updated).await {
+        Ok(file) => file,
+        Err(error) => match classify_workspace_io_error(call, error) {
+            Ok(result) => return Ok((result, AgentToolEffect::None)),
+            Err(error) => return Err(error.into()),
+        },
+    };
     session.remember_file(&file, true);
 
     let result = AgentToolResult {

--- a/src-tauri/src/application/services/agent_tools/workspace/args.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/args.rs
@@ -1,12 +1,31 @@
 use serde_json::{Map, Value};
 
 use super::policy::WorkspaceAccessPolicy;
+use crate::domain::errors::DomainError;
 use crate::domain::models::agent::{AgentToolCall, AgentToolResult, WorkspacePath};
 
 pub(super) use crate::application::services::agent_tools::common::{
-    object_args, optional_bool_arg, optional_usize_arg, required_raw_string_arg,
-    required_trimmed_string_arg, tool_error,
+    object_args, optional_bool_arg, optional_usize_arg, parse_workspace_conflict_message,
+    required_raw_string_arg, required_trimmed_string_arg, tool_error,
 };
+
+/// Pattern-match helper used by every read/write entry point so they all
+/// surface filesystem errors raised by the workspace repository as
+/// recoverable model-facing tool errors instead of bubbling up as
+/// `agent.internal_error`.
+pub(super) fn classify_workspace_io_error(
+    call: &AgentToolCall,
+    error: DomainError,
+) -> Result<AgentToolResult, DomainError> {
+    match error {
+        DomainError::NotFound(message) => Ok(tool_error(call, "workspace.file_not_found", &message)),
+        DomainError::Conflict(message) => {
+            let (code, detail) = parse_workspace_conflict_message(&message);
+            Ok(tool_error(call, code, detail))
+        }
+        other => Err(other),
+    }
+}
 
 pub(super) fn optional_list_path_arg(
     args: &Map<String, Value>,

--- a/src-tauri/src/application/services/agent_tools/workspace/read_file.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/read_file.rs
@@ -1,14 +1,13 @@
 use serde_json::json;
 
 use super::args::{
-    ensure_visible_workspace_path, object_args, optional_usize_arg, parse_workspace_path,
-    required_trimmed_string_arg, tool_error,
+    classify_workspace_io_error, ensure_visible_workspace_path, object_args, optional_usize_arg,
+    parse_workspace_path, required_trimmed_string_arg, tool_error,
 };
 use super::policy::workspace_access_policy;
 use super::render::{format_lines_with_numbers, split_lines_for_display};
 use super::{MAX_PARTIAL_READ_CHARS, MAX_READ_BYTES, MAX_READ_LINES};
 use crate::application::errors::ApplicationError;
-use crate::domain::errors::DomainError;
 use crate::domain::models::agent::{AgentToolCall, AgentToolResult};
 use crate::domain::repositories::workspace_repository::WorkspaceRepository;
 
@@ -146,13 +145,10 @@ pub(in crate::application::services::agent_tools) async fn read_file(
 
     let file = match workspace_repository.read_text(run_id, &path).await {
         Ok(file) => file,
-        Err(DomainError::NotFound(message)) => {
-            return Ok((
-                tool_error(call, "workspace.file_not_found", &message),
-                AgentToolEffect::None,
-            ));
-        }
-        Err(error) => return Err(error.into()),
+        Err(error) => match classify_workspace_io_error(call, error) {
+            Ok(result) => return Ok((result, AgentToolEffect::None)),
+            Err(error) => return Err(error.into()),
+        },
     };
 
     let lines = split_lines_for_display(&file.text);

--- a/src-tauri/src/application/services/agent_tools/workspace/specs.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/specs.rs
@@ -47,7 +47,7 @@ pub(in crate::application::services::agent_tools) fn workspace_read_file_spec() 
         name: WORKSPACE_READ_FILE.to_string(),
         model_name: MODEL_WORKSPACE_READ_FILE.to_string(),
         title: "Workspace Read File".to_string(),
-        description: "Read a visible UTF-8 Agent workspace file with line numbers. Fully read a file before using workspace_apply_patch on it; partial reads are only for inspection.".to_string(),
+        description: "Read a visible UTF-8 Agent workspace file with line numbers. Fully read a file before using workspace_apply_patch on it; partial reads are only for inspection. `path` MUST refer to a regular file (e.g. `persist/MEMORY.md`), NOT a directory or workspace root (`persist`, `output`, ...). Call workspace_list_files first when you do not know which file to open.".to_string(),
         input_schema: json!({
             "type": "object",
             "additionalProperties": false,

--- a/src-tauri/src/application/services/agent_tools/workspace/specs.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/specs.rs
@@ -208,7 +208,7 @@ pub(in crate::application::services::agent_tools) fn workspace_commit_spec() -> 
         name: WORKSPACE_COMMIT.to_string(),
         model_name: MODEL_WORKSPACE_COMMIT.to_string(),
         title: "Workspace Commit".to_string(),
-        description: "Commit a workspace text file to the current chat message. With no arguments, replace the current run message with output/main.md. append adds the file text to the same message, creating it when this run has not committed yet.".to_string(),
+        description: "Commit a workspace text file to the current chat message. With no arguments, replace the current run message with output/main.md. append adds the file text to the same message, creating it when this run has not committed yet. You MUST call workspace_finish in the SAME tool turn (or the immediately following one) after the final commit; never reply with plain text after a commit. Replying with plain text after a commit is treated as instruction drift, fails the run, and rolls the commit back.".to_string(),
         input_schema: json!({
             "type": "object",
             "additionalProperties": false,

--- a/src-tauri/src/application/services/agent_tools/workspace/tests.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/tests.rs
@@ -1,8 +1,9 @@
 use serde_json::json;
 
-use super::args::optional_list_path_arg;
+use super::args::{classify_workspace_io_error, optional_list_path_arg};
 use super::policy::WorkspaceAccessPolicy;
-use crate::domain::models::agent::WorkspacePath;
+use crate::domain::errors::DomainError;
+use crate::domain::models::agent::{AgentToolCall, WorkspacePath};
 
 fn test_policy() -> WorkspaceAccessPolicy {
     let roots = ["output", "scratch", "plan", "summaries", "persist"]
@@ -54,4 +55,64 @@ fn list_path_arg_treats_empty_and_dot_as_workspace_root() {
                 .is_none()
         );
     }
+}
+
+fn make_test_tool_call(name: &str) -> AgentToolCall {
+    AgentToolCall {
+        id: "call_test".to_string(),
+        name: name.to_string(),
+        arguments: json!({}),
+        provider_metadata: json!({}),
+    }
+}
+
+#[test]
+fn classify_conflict_error_maps_to_path_is_directory() {
+    // Issue #54: a directory hit on workspace_read_file used to surface as
+    // `agent.internal_error`. The tool layer now classifies the
+    // repository's structured Conflict into the recoverable
+    // `workspace.path_is_directory` business error so the model can
+    // self-correct by calling workspace_list_files.
+    let call = make_test_tool_call("workspace.read_file");
+    let error = DomainError::Conflict(
+        "workspace.path_is_directory: workspace path `persist` is a directory".to_string(),
+    );
+
+    let result = classify_workspace_io_error(&call, error)
+        .expect("conflict must classify into a tool result, not a hard error");
+
+    assert!(result.is_error);
+    assert_eq!(
+        result.error_code.as_deref(),
+        Some("workspace.path_is_directory")
+    );
+    assert!(
+        result.content.contains("persist"),
+        "tool error content should preserve the offending path: {}",
+        result.content
+    );
+}
+
+#[test]
+fn classify_not_found_error_maps_to_file_not_found() {
+    let call = make_test_tool_call("workspace.read_file");
+    let error = DomainError::NotFound("Workspace file not found: persist/MEMORY.md".to_string());
+
+    let result = classify_workspace_io_error(&call, error)
+        .expect("not found must classify into a tool result");
+
+    assert!(result.is_error);
+    assert_eq!(result.error_code.as_deref(), Some("workspace.file_not_found"));
+}
+
+#[test]
+fn classify_unknown_error_bubbles_up_for_host_failure() {
+    let call = make_test_tool_call("workspace.read_file");
+    let error = DomainError::InternalError("disk pressure".to_string());
+
+    let result = classify_workspace_io_error(&call, error);
+    assert!(
+        result.is_err(),
+        "infrastructural errors must remain host-level failures",
+    );
 }

--- a/src-tauri/src/application/services/agent_tools/workspace/write_file.rs
+++ b/src-tauri/src/application/services/agent_tools/workspace/write_file.rs
@@ -1,8 +1,8 @@
 use serde_json::json;
 
 use super::args::{
-    ensure_writable_workspace_path, object_args, parse_workspace_path, required_raw_string_arg,
-    required_trimmed_string_arg, tool_error,
+    classify_workspace_io_error, ensure_writable_workspace_path, object_args, parse_workspace_path,
+    required_raw_string_arg, required_trimmed_string_arg, tool_error,
 };
 use super::policy::workspace_access_policy;
 use crate::application::errors::ApplicationError;
@@ -49,9 +49,13 @@ pub(in crate::application::services::agent_tools) async fn write_file(
     if let Err(result) = ensure_writable_workspace_path(call, &policy, &path) {
         return Ok((result, AgentToolEffect::None));
     }
-    let file = workspace_repository
-        .write_text(run_id, &path, content)
-        .await?;
+    let file = match workspace_repository.write_text(run_id, &path, content).await {
+        Ok(file) => file,
+        Err(error) => match classify_workspace_io_error(call, error) {
+            Ok(result) => return Ok((result, AgentToolEffect::None)),
+            Err(error) => return Err(error.into()),
+        },
+    };
     session.remember_file(&file, true);
 
     let result = AgentToolResult {

--- a/src-tauri/src/domain/errors.rs
+++ b/src-tauri/src/domain/errors.rs
@@ -24,6 +24,9 @@ pub enum DomainError {
 
     #[error("{0}")]
     Transient(String),
+
+    #[error("{0}")]
+    Conflict(String),
 }
 
 impl DomainError {
@@ -43,6 +46,11 @@ impl DomainError {
 
     pub fn transient(message: impl Into<String>) -> Self {
         Self::Transient(message.into())
+    }
+
+    #[allow(dead_code)]
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict(message.into())
     }
 }
 

--- a/src-tauri/src/infrastructure/lan_sync/server.rs
+++ b/src-tauri/src/infrastructure/lan_sync/server.rs
@@ -417,6 +417,7 @@ fn map_domain_error(error: DomainError) -> (StatusCode, String) {
         DomainError::InternalError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
         DomainError::RateLimited { message } => (StatusCode::TOO_MANY_REQUESTS, message),
         DomainError::Transient(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
+        DomainError::Conflict(message) => (StatusCode::CONFLICT, message),
     }
 }
 

--- a/src-tauri/src/infrastructure/repositories/file_agent_repository/tests.rs
+++ b/src-tauri/src/infrastructure/repositories/file_agent_repository/tests.rs
@@ -6,6 +6,7 @@ use tokio::fs;
 use uuid::Uuid;
 
 use super::FileAgentRepository;
+use crate::domain::errors::DomainError;
 use crate::domain::models::agent::plan::{AgentPlanMode, AgentPlanPolicy};
 use crate::domain::models::agent::profile::{
     AGENT_PROFILE_KIND, AGENT_PROFILE_SCHEMA_VERSION, AgentContextPolicy, AgentModelBinding,
@@ -221,6 +222,81 @@ async fn repository_round_trips_run_workspace_event_and_checkpoint() {
         .await
         .expect("checkpoint");
     assert_eq!(checkpoint.files[0].bytes, 5);
+
+    fs::remove_dir_all(root).await.expect("cleanup");
+}
+
+#[tokio::test]
+async fn read_text_on_directory_returns_conflict_error() {
+    // Issue #54: workspace_read_file used to bubble up the raw EISDIR
+    // ("Is a directory") OS error as `agent.internal_error` (retryable=false)
+    // and tear down the whole run. We now translate it into a structured
+    // `DomainError::Conflict` so the tool layer can surface it as a
+    // recoverable `workspace.path_is_directory` business error.
+    let root = temp_root();
+    let repository = FileAgentRepository::new(root.clone());
+    let run = sample_run_with_id("run_dir_read");
+    let manifest = sample_manifest(&run);
+    let profile = sample_resolved_profile(&manifest);
+
+    repository.create_run(&run).await.expect("create run");
+    repository
+        .initialize_run(&run, &manifest, &serde_json::json!({"messages": []}), &profile)
+        .await
+        .expect("initialize workspace");
+
+    let persist_path = WorkspacePath::parse("persist").expect("persist root path");
+    let error = repository
+        .read_text(&run.id, &persist_path)
+        .await
+        .expect_err("reading a directory must fail");
+
+    match error {
+        DomainError::Conflict(message) => {
+            assert!(
+                message.starts_with("workspace.path_is_directory:"),
+                "expected workspace.path_is_directory conflict, got `{message}`"
+            );
+            assert!(
+                message.contains("persist"),
+                "conflict message should mention offending path, got `{message}`"
+            );
+        }
+        other => panic!("expected DomainError::Conflict, got {other:?}"),
+    }
+
+    fs::remove_dir_all(root).await.expect("cleanup");
+}
+
+#[tokio::test]
+async fn write_text_on_directory_returns_conflict_error() {
+    // Same guard for write_text so workspace_write_file cannot wipe out a
+    // directory through the temp-file swap path.
+    let root = temp_root();
+    let repository = FileAgentRepository::new(root.clone());
+    let run = sample_run_with_id("run_dir_write");
+    let manifest = sample_manifest(&run);
+    let profile = sample_resolved_profile(&manifest);
+
+    repository.create_run(&run).await.expect("create run");
+    repository
+        .initialize_run(&run, &manifest, &serde_json::json!({"messages": []}), &profile)
+        .await
+        .expect("initialize workspace");
+
+    let output_root = WorkspacePath::parse("output").expect("output root path");
+    let error = repository
+        .write_text(&run.id, &output_root, "should not land")
+        .await
+        .expect_err("writing to a directory must fail");
+
+    match error {
+        DomainError::Conflict(message) => {
+            assert!(message.starts_with("workspace.path_is_directory:"));
+            assert!(message.contains("output"));
+        }
+        other => panic!("expected DomainError::Conflict, got {other:?}"),
+    }
 
     fs::remove_dir_all(root).await.expect("cleanup");
 }

--- a/src-tauri/src/infrastructure/repositories/file_agent_repository/workspace_store.rs
+++ b/src-tauri/src/infrastructure/repositories/file_agent_repository/workspace_store.rs
@@ -83,6 +83,7 @@ impl WorkspaceRepository for FileAgentRepository {
         text: &str,
     ) -> Result<WorkspaceFile, DomainError> {
         let target = self.safe_workspace_path(run_id, path, true).await?;
+        ensure_target_is_not_directory(&target, path).await?;
         let temp_path = unique_temp_path(&target, "workspace.txt");
         fs::write(&temp_path, text.as_bytes())
             .await
@@ -104,6 +105,7 @@ impl WorkspaceRepository for FileAgentRepository {
         path: &WorkspacePath,
     ) -> Result<WorkspaceFile, DomainError> {
         let target = self.safe_workspace_path(run_id, path, false).await?;
+        ensure_target_is_not_directory(&target, path).await?;
         let text = fs::read_to_string(&target).await.map_err(|error| {
             if error.kind() == std::io::ErrorKind::NotFound {
                 DomainError::NotFound(format!("Workspace file not found: {}", path.as_str()))
@@ -298,5 +300,31 @@ impl WorkspaceRepository for FileAgentRepository {
         let _guard = self.persist_lock.lock().await;
         let changes = self.compute_persistent_changes(run_id).await?;
         self.commit_persistent_state(run_id, changes).await
+    }
+}
+
+/// Reject calls that target an existing directory at `target`. The OS error
+/// for `read_to_string` on a directory (EISDIR / "Is a directory") used to
+/// bubble up as `DomainError::InternalError`, surfaced to the model as a
+/// non-retryable `agent.internal_error`. We translate it into a structured
+/// `DomainError::Conflict` so the tool layer can return a recoverable
+/// `workspace.path_is_directory` business error and prompt the model to use
+/// `workspace_list_files` instead.
+async fn ensure_target_is_not_directory(
+    target: &std::path::Path,
+    workspace_path: &WorkspacePath,
+) -> Result<(), DomainError> {
+    match fs::symlink_metadata(target).await {
+        Ok(metadata) if metadata.file_type().is_dir() => Err(DomainError::Conflict(format!(
+            "workspace.path_is_directory: workspace path `{}` is a directory; use workspace_list_files to list its contents and re-target a specific file.",
+            workspace_path.as_str()
+        ))),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(DomainError::InternalError(format!(
+            "Failed to inspect workspace path {}: {}",
+            target.display(),
+            error
+        ))),
     }
 }

--- a/src-tauri/src/presentation/errors.rs
+++ b/src-tauri/src/presentation/errors.rs
@@ -49,6 +49,7 @@ impl From<DomainError> for CommandError {
             DomainError::InternalError(msg) => CommandError::InternalServerError(msg),
             DomainError::RateLimited { message } => CommandError::TooManyRequests(message),
             DomainError::Transient(msg) => CommandError::InternalServerError(msg),
+            DomainError::Conflict(msg) => CommandError::BadRequest(msg),
         }
     }
 }


### PR DESCRIPTION
本 PR 解决两个 agent runtime 健壮性 issue 的**后端部分**。前端 UI 闭环走单独的 PR（见 follow-up）。

## Summary

### Issue #54: workspace IO tools 把目录访问翻译成业务级错误

之前 `workspace_read_file` / `workspace_write_file` / `workspace_apply_patch` / `workspace.commit` 在 model 把目录路径（如 \`persist\` / \`output\`）当文件读写时，OS 抛 \`EISDIR\` → \`DomainError::InternalError\` → \`agent.internal_error\` + \`retryable=false\`，run 直接崩。

修复链路（严格 Clean Architecture，3 处穷尽 match 同步更新）：

- \`DomainError::Conflict(String)\` 新增 → \`ApplicationError::ValidationError\` / \`CommandError::BadRequest\` / HTTP 409。
- \`file_agent_repository::workspace_store::ensure_target_is_not_directory\` 在 \`read_text\` / \`write_text\` 前用 \`fs::symlink_metadata\` 探测，目录目标抛 \`DomainError::Conflict("workspace.path_is_directory: ...")\`。
- 共享 \`parse_workspace_conflict_message\` 放在 \`agent_tools/common.rs\`，\`pub(crate)\` 暴露，workspace 工具的 \`classify_workspace_io_error\` 和 runtime-service 的 \`perform_host_chat_commit\` 复用同一 source of truth（不重复造轮子）。
- \`workspace_read_file\` description 强化，明确禁止目录目标，提示使用 \`workspace_list_files\`。

### Issue #55: instruction drift 后端事件

当模型在 \`workspace.commit\` 后回纯文本、tool_calls 为空、tool_after_finish、max_tool_rounds_exceeded 等漂移场景，之前：committed 的 chat 消息留作孤儿，无法回滚；UI 也没拿到 retry 信号。

- \`loop_runner\` 跟踪每一次 \`AgentToolEffect::ChatCommitted\`。
- 漂移触发时 emit \`run_rollback_targets\` warn event（**在 \`run_failed\` 之前**），载荷含每条 committed message 的 \`{ path, mode, messageId, round }\`。
- \`run_failed\` payload 新增 \`userRetryable: bool\`：\`retryable=true\` 时为 true；drift codes（\`model.tool_call_required\` / \`agent.tool_after_finish\` / \`agent.max_tool_rounds_exceeded\`）即使 \`retryable=false\` 也设为 \`userRetryable=true\`。
- \`workspace.commit\` description 强化"必须 same-or-next turn 调 \`workspace.finish\`，不准回纯文本"契约。
- \`docs/Agent/RunEventJournal.md\` + \`docs/Agent/ToolSystem.md\` 同步更新。

## Commits

- \`fdeca94\` chore: ignore local .cursor/ skill workspace
- \`44997a1\` fix(agent): translate workspace directory access to recoverable tool error (#54)
- \`fb23853\` fix(agent): emit run_rollback_targets + userRetryable on instruction drift (#55)

## 改动范围

21 个文件，主要在 \`src-tauri/src/{domain,application,infrastructure,presentation}/\`，没有任何 vendor 文件改动，所有改动遵守仓库 \`.cursor/skills/tauritavern-contribution/SKILL.md\`（项目 contribution skill，本 PR 不进版本控制因为在 .gitignore）。

## 验证

\`cargo test --lib\` 589 全绿（含 11 个新增测试覆盖 \`DomainError::Conflict\` 转换、\`classify_workspace_io_error\`、\`userRetryable\` 各 drift code、以及 end-to-end \`foreground_run_emits_rollback_targets_on_tool_call_required_drift\` 集成测试）。

## 关联 PR

- 前端 UI 闭环（让 Retry 按钮 / drift 消息回滚 / send 解锁真正生效）走单独 PR，依赖本 PR 合并。

## Test plan

- [ ] 让 agent 把 \`workspace_read_file\` 的 path 设成 \`persist\`（一个 workspace root），确认返回 \`workspace.path_is_directory\` 业务错误而不是 \`agent.internal_error\`，且 run 不崩
- [ ] 触发模型在 commit 后回纯文本的 drift 场景，确认事件 journal 里能看到 \`run_rollback_targets\`，\`run_failed.userRetryable === true\`
- [ ] cargo test --lib 通过

Made with [Cursor](https://cursor.com)