### PR TITLE
feat(agent): soft fallback for drift / dispatch / finish failures (#69)

### DIFF
--- a/docs/Agent/RunEventJournal.md
+++ b/docs/Agent/RunEventJournal.md
@@ -207,7 +207,70 @@ run_failed
 ```
 
 - 恢复成功 → run 继续，不会发 `run_rollback_targets`，也不会写 `run_failed`
-- 恢复失败（模型再次返回 0 tool_calls）→ 回落到原 #55 路径，发 `run_rollback_targets` + `run_failed`（`userRetryable=true`），允许用户手动重试
+- 恢复失败（模型再次返回 0 tool_calls）：
+  - **如果该 run 已通过 `workspace.commit` 发布过消息** → 走 issue #69 **soft fallback**：写一条 `drift_soft_finished` 警告事件、然后正常调用 `finish_run`。run 状态为 `Completed`，已 commit 的 chat 消息保留，**不**回滚、**不**发 `run_failed`。宿主 UI 应据此事件展示"已完成但有警告"标记。
+  - **如果该 run 未 commit 任何 chat** → 回落到原 #55 路径，发 `run_rollback_targets` + `run_failed`（`userRetryable=true`），允许用户手动重试。
+
+**Soft fallback（issue #69）**：核心原则是"已 commit 的工作不能丢"。除了上面的 drift 恢复失败外，以下两个 drift 形态也复用同一兜底：
+
+| Drift 形态 | 已 commit? | 行为 |
+|------------|-----------|------|
+| `model.tool_call_required`（drift recovery 耗尽） | 是 | 发 `drift_soft_finished` → `finish_run` → `run_completed` |
+| `model.tool_call_required`（drift recovery 耗尽） | 否 | 发 `run_rollback_targets`（空）→ `run_failed` |
+| `agent.tool_after_finish`（finish 之后又调工具） | 是 | 发 `drift_soft_skipped_post_finish_tool` per 多余调用 → 走 finish 继续 → `run_completed` |
+| `agent.tool_after_finish` | 否 | 发 `run_rollback_targets`（空）→ `run_failed` |
+| `agent.max_tool_rounds_exceeded`（轮数耗尽未 finish） | 是 | 发 `drift_soft_finished` → `finish_run` → `run_completed` |
+| `agent.max_tool_rounds_exceeded` | 否 | 发 `run_rollback_targets`（空）→ `run_failed` |
+
+`drift_soft_finished` payload：
+
+```json
+{
+  "reasonCode": "model.tool_call_required",
+  "round": 9,
+  "preservedCommitCount": 1,
+  "preservedCommits": [
+    {
+      "path": "output/main.md",
+      "mode": "replace",
+      "messageId": "10",
+      "round": 8
+    }
+  ]
+}
+```
+
+`drift_soft_skipped_post_finish_tool` payload（每个多余调用一条）：
+
+```json
+{
+  "round": 5,
+  "callId": "call_extra",
+  "name": "workspace_apply_patch",
+  "reasonCode": "agent.tool_after_finish"
+}
+```
+
+**`persistent_changes_commit_failed` soft degrade（issue #69）**：当 `finish_run` 内部的持久化提交失败（磁盘满、journal 损坏…），不再硬失败整个 run。仍发 `persistent_changes_commit_failed`（payload 多一个 `softDegraded: true` 标记），但继续走 `Completed` 状态 — 已通过 `workspace.commit` 写出的 chat 消息不能因为持久化层故障被吞掉。宿主 UI 应监听这两个事件出现在同一 run 时，按"已完成但跨 run 状态丢失"展示。
+
+**Dispatch-time 错误的软化（issue #69）**：先前 `dispatch_tool_call` 在两种情况下硬失败整个 run：
+
+1. 模型调用了一个不存在的工具名（`model.unknown_tool_call`）；
+2. 工具实现层抛出 `ValidationError` / `NotFound` / `RateLimited` / `Transient`。
+
+现在这些都改为把错误以 `recoverable_tool_error` 的形式回填到下一轮 tool result，让模型自行更正。会同时发一条 `tool_dispatch_soft_recovered` 警告事件方便排查：
+
+```json
+{
+  "round": 3,
+  "callId": "call_typo",
+  "name": "workspaze_read_file",
+  "code": "model.unknown_tool_call",
+  "message": "Unknown Agent tool `workspaze_read_file`. ..."
+}
+```
+
+`InternalError` / `PermissionDenied` / `Unauthorized` / `Cancelled` 仍然保留原本的硬失败行为，因为这几类不是模型能自己修复的。
 
 ### 4.2 Workspace
 

--- a/docs/Agent/RunEventJournal.md
+++ b/docs/Agent/RunEventJournal.md
@@ -140,6 +140,7 @@ run_committed
 run_completed
 run_cancel_requested
 run_cancelled
+drift_recovery_attempted
 run_rollback_targets
 run_failed
 ```
@@ -154,6 +155,7 @@ status_changed
 run_completed
 run_cancel_requested
 run_cancelled
+drift_recovery_attempted
 run_rollback_targets
 run_failed
 ```
@@ -191,6 +193,21 @@ run_failed
   ]
 }
 ```
+
+**Soft drift recovery（issue #64）**：在直接 fail-fast 之前，loop runner 会先做一次"软纠正"：当模型返回 0 tool_calls 时，把它的纯文本回复推进 history，再追加一条合成的 `user` 消息提醒它必须调用 `workspace_finish`（或 `workspace_apply_patch` + `workspace_finish`），然后让它在下一轮再试一次。每个 run 至多 1 次（受 `DRIFT_RECOVERY_MAX_ATTEMPTS` 控制）。每次尝试都会写一条 `drift_recovery_attempted` 事件，便于宿主 UI 给用户显示"系统正在纠正…"提示：
+
+```json
+{
+  "attempt": 1,
+  "maxAttempts": 1,
+  "round": 9,
+  "committedCount": 1,
+  "reasonCode": "model.tool_call_required"
+}
+```
+
+- 恢复成功 → run 继续，不会发 `run_rollback_targets`，也不会写 `run_failed`
+- 恢复失败（模型再次返回 0 tool_calls）→ 回落到原 #55 路径，发 `run_rollback_targets` + `run_failed`（`userRetryable=true`），允许用户手动重试
 
 ### 4.2 Workspace
 

--- a/docs/Agent/ToolSystem.md
+++ b/docs/Agent/ToolSystem.md
@@ -197,9 +197,16 @@ persist/
 如果模型一回合内仍然返回 0 个 tool_calls（drift），loop runner 会先做一次"软纠正"（issue #64）：把模型的纯文本回复推进 history，再追加一条 `user` 角色的合成提醒，让模型在下一轮重试。**每个 run 至多 1 次**（常量 `DRIFT_RECOVERY_MAX_ATTEMPTS`），每次都会写一条 `drift_recovery_attempted` 事件。
 
 - 软纠正后模型调用了 `workspace_finish`（或继续修订）→ run 继续，无 rollback。
-- 软纠正失败（模型再次 0 tool_calls）→ 回落到 `model.tool_call_required` 失败路径，发 `run_rollback_targets` + `run_failed`（`userRetryable=true`）。
+- 软纠正失败（模型再次 0 tool_calls）→ **issue #69 soft fallback**：若该 run 已 commit 过 chat 消息，loop runner 改为发 `drift_soft_finished` 事件并继续走 `finish_run`（run 状态 `Completed`，commit 保留）；若没有任何 commit，保持原 `run_rollback_targets` + `run_failed`（`userRetryable=true`）路径让用户手动重试。
 
-违反此契约的其它形态（`agent.tool_after_finish` / `agent.max_tool_rounds_exceeded`）目前不走软纠正、直接发 `run_rollback_targets`，原因是这两种 drift 本身已经发生了真实的工具调用，软纠正空间小。细节见 `RunEventJournal.md`。
+其它 drift 形态也复用同一兜底（issue #69）：
+
+- `agent.tool_after_finish`（模型在 finish 后又请求工具）：已 commit 时跳过多余调用（每条写 `drift_soft_skipped_post_finish_tool`）继续走 finish；未 commit 时维持原 `run_rollback_targets` + `run_failed`。
+- `agent.max_tool_rounds_exceeded`（轮数耗尽未 finish）：已 commit 时发 `drift_soft_finished` 并自动 finish；未 commit 时维持原失败路径。
+- `finish_run` 内部 `commit_persistent_changes` 失败：保留 chat commit，`persistent_changes_commit_failed` payload 带 `softDegraded: true`，run 仍走 `Completed`。
+- `dispatch_tool_call` 阶段的 `ValidationError` / `NotFound` / `RateLimited` / `Transient` / 未知工具名：改为以 `recoverable_tool_error` 回填给下一轮 tool result，写 `tool_dispatch_soft_recovered` 事件；`InternalError` / `PermissionDenied` / `Unauthorized` / `Cancelled` 维持原硬失败。
+
+核心原则："已通过 `workspace.commit` 写出的工作绝不丢"。细节与 payload 形态见 `RunEventJournal.md`。
 
 当前没有 MCP、shell、extension bridge、profile routing、Plan Mode runtime 或审批工具。
 

--- a/docs/Agent/ToolSystem.md
+++ b/docs/Agent/ToolSystem.md
@@ -192,7 +192,14 @@ persist/
 
 `workspace.apply_patch` 使用 Claude Code 风格的 `old_string` / `new_string` 单文件精确替换。未完整读取、版本变化、匹配 0 次或多次会作为 recoverable tool error 返回模型。模型传入的非法 path、空 path、不可见/不可写 path 也作为可恢复工具错误回填；目标 path 实际指向目录的读写请求会作为 `workspace.path_is_directory` 业务错误回填，提示模型改用 `workspace_list_files`。repository 内部 escape/symlink/journal、checkpoint、序列化、取消和模型响应结构错误仍 fail-fast。
 
-`workspace.commit` 与 `workspace.finish` 的契约：模型必须在最后一次 commit 之后的同一回合或紧随其后调用 `workspace.finish`，**不允许**在 commit 后回纯文本。违反此契约（包括 `model.tool_call_required` / `agent.tool_after_finish` / `agent.max_tool_rounds_exceeded`）属于 instruction drift，run 会以 `userRetryable=true` 失败，并通过 `run_rollback_targets` 事件给出本次 run 已 commit 的 message 列表供宿主 UI 回滚；细节见 `RunEventJournal.md`。
+`workspace.commit` 与 `workspace.finish` 的契约：模型必须在最后一次 commit 之后的同一回合或紧随其后调用 `workspace.finish`，**不允许**在 commit 后回纯文本。`workspace.commit` 工具的返回字符串本身会带强提示（"REQUIRED NEXT STEP: call workspace_finish..."），降低模型 drift 概率。
+
+如果模型一回合内仍然返回 0 个 tool_calls（drift），loop runner 会先做一次"软纠正"（issue #64）：把模型的纯文本回复推进 history，再追加一条 `user` 角色的合成提醒，让模型在下一轮重试。**每个 run 至多 1 次**（常量 `DRIFT_RECOVERY_MAX_ATTEMPTS`），每次都会写一条 `drift_recovery_attempted` 事件。
+
+- 软纠正后模型调用了 `workspace_finish`（或继续修订）→ run 继续，无 rollback。
+- 软纠正失败（模型再次 0 tool_calls）→ 回落到 `model.tool_call_required` 失败路径，发 `run_rollback_targets` + `run_failed`（`userRetryable=true`）。
+
+违反此契约的其它形态（`agent.tool_after_finish` / `agent.max_tool_rounds_exceeded`）目前不走软纠正、直接发 `run_rollback_targets`，原因是这两种 drift 本身已经发生了真实的工具调用，软纠正空间小。细节见 `RunEventJournal.md`。
 
 当前没有 MCP、shell、extension bridge、profile routing、Plan Mode runtime 或审批工具。
 

--- a/src-tauri/src/application/services/agent_runtime_service/commit.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/commit.rs
@@ -267,35 +267,47 @@ impl AgentRuntimeService {
         self.transition_status(run_id, AgentRunStatus::Finishing)
             .await?;
 
-        let persistent_changes = match self
+        // Issue #69: never let a persistent-state commit failure throw
+        // away the chat message the model already committed. If
+        // `commit_persistent_changes` fails (disk full, journal corrupt,
+        // …), we emit `persistent_changes_commit_failed` as before, then
+        // continue with run completion so the user still sees the
+        // committed chat. The host UI should treat a `run_completed`
+        // event that follows a `persistent_changes_commit_failed` event
+        // as "completed with warnings" — persistent (cross-run) state
+        // for this run was discarded.
+        match self
             .workspace_repository
             .commit_persistent_changes(run_id)
             .await
         {
-            Ok(changes) => changes,
+            Ok(persistent_changes) => {
+                self.event(
+                    run_id,
+                    AgentRunEventLevel::Info,
+                    "persistent_changes_committed",
+                    json!({
+                        "stateId": persistent_changes.state_id,
+                        "baseStateId": persistent_changes.base_state_id,
+                        "changeCount": persistent_changes.changes.len(),
+                        "changes": &persistent_changes.changes,
+                    }),
+                )
+                .await?;
+            }
             Err(error) => {
                 self.event(
                     run_id,
                     AgentRunEventLevel::Error,
                     "persistent_changes_commit_failed",
-                    json!({ "message": error.to_string() }),
+                    json!({
+                        "message": error.to_string(),
+                        "softDegraded": true,
+                    }),
                 )
                 .await?;
-                return Err(error.into());
             }
-        };
-        self.event(
-            run_id,
-            AgentRunEventLevel::Info,
-            "persistent_changes_committed",
-            json!({
-                "stateId": persistent_changes.state_id,
-                "baseStateId": persistent_changes.base_state_id,
-                "changeCount": persistent_changes.changes.len(),
-                "changes": &persistent_changes.changes,
-            }),
-        )
-        .await?;
+        }
 
         self.transition_status(run_id, AgentRunStatus::Completed)
             .await?;

--- a/src-tauri/src/application/services/agent_runtime_service/commit.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/commit.rs
@@ -214,7 +214,13 @@ impl AgentRuntimeService {
                         call_id: call.id.clone(),
                         name: call.name.clone(),
                         content: format!(
-                            "Committed {} to the current chat message with mode {:?}.",
+                            "Committed {} to the current chat message with mode {:?}. \
+                             REQUIRED NEXT STEP: call workspace_finish to complete the run. \
+                             If you need to revise the committed content, call \
+                             workspace_apply_patch (or workspace_write_file then workspace_commit \
+                             again) first, then call workspace_finish. DO NOT reply with plain \
+                             text after a commit: that is treated as instruction drift, fails the \
+                             run, and rolls back this commit.",
                             path.as_str(),
                             mode
                         ),
@@ -222,6 +228,7 @@ impl AgentRuntimeService {
                             "path": path.as_str(),
                             "mode": mode,
                             "messageId": result.message_id.as_deref(),
+                            "nextRequiredTool": "workspace_finish",
                         }),
                         is_error: false,
                         error_code: None,

--- a/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
@@ -10,9 +10,17 @@ use crate::application::errors::ApplicationError;
 use crate::application::services::agent_tools::{AgentToolEffect, AgentToolSession};
 use crate::domain::models::agent::profile::ResolvedAgentProfile;
 use crate::domain::models::agent::{
-    AgentChatCommitMode, AgentModelRequest, AgentRunEventLevel, AgentRunStatus, AgentToolResult,
-    WorkspacePath,
+    AgentChatCommitMode, AgentModelContentPart, AgentModelMessage, AgentModelRequest,
+    AgentModelRole, AgentRunEventLevel, AgentRunStatus, AgentToolResult, WorkspacePath,
 };
+
+/// How many in-loop drift recovery attempts to make per run before
+/// surrendering to the existing #55 fail-fast path. One attempt is
+/// enough for the common case (model forgets `workspace_finish` after
+/// the final commit) without burning excessive tokens on stubborn
+/// drifters; raise this only after we have data showing repeat drifts
+/// are common AND benign.
+const DRIFT_RECOVERY_MAX_ATTEMPTS: usize = 1;
 
 /// Tracks a chat commit that the model produced during this run. When the
 /// run later fails because of instruction drift (issue #55), we surface
@@ -37,6 +45,11 @@ impl AgentRuntimeService {
         let mut tool_session = AgentToolSession::default();
         let mut commit_count = 0_usize;
         let mut committed_messages: Vec<CommittedChatMessage> = Vec::new();
+        // Issue #64: counter for soft drift recovery — see
+        // `DRIFT_RECOVERY_MAX_ATTEMPTS` above. Persisted across rounds so a
+        // single run gets at most N corrective nudges in total, not N per
+        // drift event.
+        let mut drift_recovery_attempts: usize = 0;
         for round in 1..=profile.tools.max_rounds {
             self.transition_status(run_id, AgentRunStatus::CallingModel)
                 .await?;
@@ -96,6 +109,48 @@ impl AgentRuntimeService {
             .await?;
 
             if tool_calls.is_empty() {
+                // Issue #64: instead of failing the run immediately, give the
+                // model one chance to self-correct. The most common drift —
+                // model commits, then replies in plain text instead of
+                // calling `workspace_finish` — is a one-step contract slip,
+                // not a fundamental misunderstanding. We push the drifted
+                // assistant turn into history (so the model owns what it
+                // just said) and follow it with a synthetic `user` reminder.
+                // Multi-turn pattern is API-compatible with both Anthropic
+                // and OpenAI chat completions (no role-alternation
+                // constraint after a no-tool-use turn).
+                let can_recover = drift_recovery_attempts < DRIFT_RECOVERY_MAX_ATTEMPTS
+                    && round < profile.tools.max_rounds;
+                if can_recover {
+                    drift_recovery_attempts += 1;
+                    let committed_count = committed_messages.len();
+                    let nudge_text = build_drift_recovery_nudge(
+                        committed_count,
+                        drift_recovery_attempts,
+                        DRIFT_RECOVERY_MAX_ATTEMPTS,
+                    );
+                    request.messages.push(response.message.clone());
+                    request.messages.push(AgentModelMessage {
+                        role: AgentModelRole::User,
+                        parts: vec![AgentModelContentPart::Text { text: nudge_text }],
+                        provider_metadata: Value::Null,
+                    });
+                    self.event(
+                        run_id,
+                        AgentRunEventLevel::Warn,
+                        "drift_recovery_attempted",
+                        json!({
+                            "attempt": drift_recovery_attempts,
+                            "maxAttempts": DRIFT_RECOVERY_MAX_ATTEMPTS,
+                            "round": round,
+                            "committedCount": committed_count,
+                            "reasonCode": "model.tool_call_required",
+                        }),
+                    )
+                    .await?;
+                    self.ensure_not_cancelled(cancel)?;
+                    continue;
+                }
                 self.emit_run_rollback_targets(run_id, &committed_messages, "model.tool_call_required", round)
                     .await?;
                 return Err(ApplicationError::ValidationError(
@@ -333,6 +388,42 @@ impl AgentRuntimeService {
         }
 
         Ok(hydrated)
+    }
+}
+
+/// Build the corrective `user` message we inject when the model returns a
+/// turn with zero tool calls. The phrasing covers both common drift modes:
+///
+/// * **Post-commit drift** (committed_count > 0): model committed a chat
+///   message but then replied with plain text instead of calling
+///   `workspace_finish`. We tell it that the commit will be rolled back if
+///   it doesn't finish, and that it can use `workspace_apply_patch` if it
+///   wants to revise the committed content.
+/// * **No-commit drift** (committed_count == 0): model bypassed the tool
+///   workflow entirely. We tell it that every turn must use a tool until
+///   `workspace_finish`.
+///
+/// The attempt counter is included so the model can see we have a hard
+/// budget; if attempt == max_attempts there is no further leniency.
+fn build_drift_recovery_nudge(committed_count: usize, attempt: usize, max_attempts: usize) -> String {
+    if committed_count > 0 {
+        format!(
+            "[system reminder, drift recovery attempt {attempt}/{max_attempts}] You replied with \
+             plain text but the run is not complete. You have committed {committed_count} \
+             message(s) to the chat via workspace_commit; you MUST finalize the run by calling \
+             workspace_finish, or the commit(s) will be ROLLED BACK and the run will fail. If \
+             you need to revise the committed content, call workspace_apply_patch (or \
+             workspace_write_file + workspace_commit again) first, then workspace_finish. Do \
+             NOT repeat the content in plain text — that is treated as instruction drift."
+        )
+    } else {
+        format!(
+            "[system reminder, drift recovery attempt {attempt}/{max_attempts}] You replied with \
+             plain text, but every turn must use a tool until the run ends with workspace_finish. \
+             Inspect the workspace (workspace_list_files / workspace_read_file), produce the \
+             answer through workspace_write_file + workspace_commit, then call workspace_finish. \
+             Do NOT answer directly in plain text."
+        )
     }
 }
 

--- a/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/loop_runner.rs
@@ -151,6 +151,22 @@ impl AgentRuntimeService {
                     self.ensure_not_cancelled(cancel)?;
                     continue;
                 }
+                // Issue #69: drift recovery is exhausted. If the model has
+                // already committed work in this run, we *never* throw away
+                // that work — soft-fall-back to `finish_run` so the user
+                // sees the committed chat message instead of an empty
+                // rollback. Only when there is nothing to preserve do we
+                // hard-fail with `model.tool_call_required`.
+                if !committed_messages.is_empty() {
+                    self.emit_drift_soft_finished_event(
+                        run_id,
+                        &committed_messages,
+                        "model.tool_call_required",
+                        round,
+                    )
+                    .await?;
+                    return Ok(Some(commit_count));
+                }
                 self.emit_run_rollback_targets(run_id, &committed_messages, "model.tool_call_required", round)
                     .await?;
                 return Err(ApplicationError::ValidationError(
@@ -165,6 +181,29 @@ impl AgentRuntimeService {
 
             for call in tool_calls {
                 if finished {
+                    // Issue #69: model called `workspace_finish` and then
+                    // tried to queue more tools in the same round. Treat
+                    // this as a no-op for the trailing calls — the model
+                    // has already declared completion. If there were any
+                    // commits in this run, we still preserve them via the
+                    // normal finish path. With no commits we fall back to
+                    // the original hard error so the user notices something
+                    // is wrong with their prompt/profile.
+                    if !committed_messages.is_empty() {
+                        self.event(
+                            run_id,
+                            AgentRunEventLevel::Warn,
+                            "drift_soft_skipped_post_finish_tool",
+                            json!({
+                                "round": round,
+                                "callId": call.id.as_str(),
+                                "name": call.name.as_str(),
+                                "reasonCode": "agent.tool_after_finish",
+                            }),
+                        )
+                        .await?;
+                        continue;
+                    }
                     self.emit_run_rollback_targets(
                         run_id,
                         &committed_messages,
@@ -279,9 +318,21 @@ impl AgentRuntimeService {
             self.ensure_not_cancelled(cancel)?;
         }
 
-        // We ran out of rounds before workspace_finish was called. Any
-        // commits made along the way are now orphaned — surface them so the
-        // host can offer a clean Retry that rolls them back.
+        // We ran out of rounds before workspace_finish was called.
+        // Issue #69: if the model committed any chat message during the
+        // run, soft-fall-back to finishing rather than throwing the work
+        // away. With no committed work, surface the original max-rounds
+        // failure so the host can offer a Retry.
+        if !committed_messages.is_empty() {
+            self.emit_drift_soft_finished_event(
+                run_id,
+                &committed_messages,
+                "agent.max_tool_rounds_exceeded",
+                profile.tools.max_rounds,
+            )
+            .await?;
+            return Ok(Some(commit_count));
+        }
         self.emit_run_rollback_targets(
             run_id,
             &committed_messages,
@@ -291,6 +342,46 @@ impl AgentRuntimeService {
         .await?;
 
         Ok(None)
+    }
+
+    /// Emit a `drift_soft_finished` warning event documenting that we
+    /// turned a drift-class failure into a successful run completion in
+    /// order to preserve the model's committed chat output. The payload
+    /// mirrors `run_rollback_targets` so the host UI can render a clear
+    /// "completed with warnings" badge instead of either silently
+    /// succeeding (confusing) or losing the chat message (data loss).
+    /// See issue #69.
+    async fn emit_drift_soft_finished_event(
+        &self,
+        run_id: &str,
+        committed_messages: &[CommittedChatMessage],
+        reason_code: &str,
+        round: usize,
+    ) -> Result<(), ApplicationError> {
+        let targets = committed_messages
+            .iter()
+            .map(|message| {
+                json!({
+                    "path": message.path,
+                    "mode": message.mode,
+                    "messageId": message.message_id.as_deref(),
+                    "round": message.round,
+                })
+            })
+            .collect::<Vec<_>>();
+        self.event(
+            run_id,
+            AgentRunEventLevel::Warn,
+            "drift_soft_finished",
+            json!({
+                "reasonCode": reason_code,
+                "round": round,
+                "preservedCommitCount": targets.len(),
+                "preservedCommits": Value::Array(targets),
+            }),
+        )
+        .await?;
+        Ok(())
     }
 
     async fn emit_run_rollback_targets(

--- a/src-tauri/src/application/services/agent_runtime_service/tests.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/tests.rs
@@ -1126,10 +1126,14 @@ async fn foreground_run_commits_chat_message_before_finish() {
     tokio::fs::remove_dir_all(root).await.expect("cleanup");
 }
 
-/// Issue #55: when the model commits, then drifts by replying with plain
-/// text (no tool calls) in the next round, the run must fail AND emit a
-/// `run_rollback_targets` event listing the now-orphaned chat message so
-/// the host UI can roll it back and offer the user a clean Retry.
+/// Issue #55 + #64: when the model commits, then drifts by replying with
+/// plain text (no tool calls), the run gives the model **one** corrective
+/// nudge (issue #64 soft drift recovery). If it drifts AGAIN, the run
+/// must fail AND emit a `run_rollback_targets` event listing the
+/// now-orphaned chat message so the host UI can roll it back and offer
+/// the user a clean Retry. This is the failure-after-recovery path; the
+/// success path is covered by
+/// [`foreground_run_recovers_from_post_commit_drift_with_nudge`].
 #[tokio::test]
 async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
     let root = std::env::temp_dir().join(format!(
@@ -1191,13 +1195,25 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
                 }
             }]
         }),
-        // Round 3: drift — return plain text and no tool calls. This is
-        // the failure mode the issue describes.
+        // Round 3: drift — return plain text and no tool calls. With #64
+        // this triggers ONE soft recovery attempt (a corrective `user`
+        // message gets injected); the run does not fail yet.
         json!({
             "choices": [{
                 "message": {
                     "role": "assistant",
                     "content": "Sorry, here is the full answer one more time...",
+                }
+            }]
+        }),
+        // Round 4: stubborn drift — model ignores the nudge and replies
+        // with plain text again. Recovery budget is now exhausted, so the
+        // run fails and emits `run_rollback_targets`.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Sorry, here it is one more time...",
                 }
             }]
         }),
@@ -1262,6 +1278,29 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
         .await
         .expect("read events");
 
+    // #64: the first drift must have produced exactly one
+    // `drift_recovery_attempted` event before we surrendered to the
+    // rollback path. If this assertion fails it means the rollback was
+    // emitted on the first drift (recovery was bypassed) — a regression
+    // of #64.
+    let recovery_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.event_type == "drift_recovery_attempted")
+        .collect();
+    assert_eq!(
+        recovery_events.len(),
+        1,
+        "exactly one drift_recovery_attempted event must precede the rollback"
+    );
+    assert_eq!(recovery_events[0].level, AgentRunEventLevel::Warn);
+    assert_eq!(recovery_events[0].payload["attempt"], 1);
+    assert_eq!(recovery_events[0].payload["maxAttempts"], 1);
+    assert_eq!(recovery_events[0].payload["committedCount"], 1);
+    assert_eq!(
+        recovery_events[0].payload["reasonCode"],
+        "model.tool_call_required"
+    );
+
     let rollback = events
         .iter()
         .find(|event| event.event_type == "run_rollback_targets")
@@ -1275,6 +1314,379 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
     assert_eq!(targets.len(), 1);
     assert_eq!(targets[0]["messageId"], "message_42");
     assert_eq!(targets[0]["path"], "output/main.md");
+}
+
+/// Issue #64: when the model commits and then drifts (plain text, no
+/// tool calls), the loop must inject a corrective `user` reminder and
+/// give the model one more chance to call `workspace_finish`. If the
+/// model complies, the run completes normally — the commit is NOT
+/// rolled back. This is the happy-path complement to
+/// [`foreground_run_emits_rollback_targets_on_tool_call_required_drift`].
+#[tokio::test]
+async fn foreground_run_recovers_from_post_commit_drift_with_nudge() {
+    let root = std::env::temp_dir().join(format!(
+        "tauritavern-agent-drift-recovery-{}",
+        Uuid::new_v4().simple()
+    ));
+    let repository = Arc::new(FileAgentRepository::new(root.clone()));
+    let run = AgentRun {
+        id: "run_drift_recovery_test".to_string(),
+        workspace_id: "chat_drift_recovery_test".to_string(),
+        stable_chat_id: "stable_drift_recovery_test".to_string(),
+        chat_ref: AgentChatRef::Character {
+            character_id: "Seraphina".to_string(),
+            file_name: "Seraphina.png".to_string(),
+        },
+        generation_type: "normal".to_string(),
+        profile_id: None,
+        persist_base_state_id: None,
+        presentation: AgentRunPresentation::Foreground,
+        status: AgentRunStatus::Created,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    repository.create_run(&run).await.expect("create run");
+
+    let model_gateway = Arc::new(MockAgentModelGateway::new(vec![
+        // Round 1: write artifact.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_write_recovery",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_write_file",
+                            "arguments": "{\"path\":\"output/main.md\",\"content\":\"recovered answer\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 2: commit it.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_commit_recovery",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_commit",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 3: drift — model replies in plain text instead of calling
+        // workspace_finish. #64 injects a corrective nudge.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Oh and here's the answer in chat form...",
+                }
+            }]
+        }),
+        // Round 4: model reads the nudge and complies — calls
+        // workspace_finish. Run should complete cleanly.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_finish_recovery",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_finish",
+                            "arguments": "{\"reason\":\"recovered after drift\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+    ]));
+
+    let service = Arc::new(AgentRuntimeService::new(
+        repository.clone(),
+        repository.clone(),
+        repository.clone(),
+        test_chat_repository(&root),
+        test_chat_repository(&root),
+        test_skill_service(&root),
+        model_gateway.clone(),
+        test_profile_service(&root),
+    ));
+    let request = ChatCompletionGenerateRequestDto {
+        payload: json!({
+            "chat_completion_source": "openai",
+            "model": "test-model",
+            "messages": prompt_messages("drift recovery happy path")
+        })
+        .as_object()
+        .cloned()
+        .unwrap(),
+    };
+    let prompt_snapshot = json!({ "chatCompletionPayload": request.payload.clone() });
+    let (_cancel_sender, mut cancel_receiver) = watch::channel(false);
+    let mut profile = test_resolved_profile(&root).await;
+    profile.run.presentation = AgentRunPresentation::Foreground;
+
+    let resolver = tokio::spawn(resolve_next_chat_commit(
+        service.clone(),
+        repository.clone(),
+        run.id.clone(),
+        "message_recovery_42",
+    ));
+    service
+        .execute_agent_loop_run_inner(
+            &run.id,
+            prompt_snapshot,
+            request,
+            profile,
+            &mut cancel_receiver,
+        )
+        .await
+        .expect("recovery should let the run complete");
+    resolver.await.expect("resolver task");
+
+    let saved = repository.load_run(&run.id).await.expect("load run");
+    assert_eq!(saved.status, AgentRunStatus::Completed);
+
+    let events = repository
+        .read_events(
+            &run.id,
+            AgentRunEventReadQuery {
+                after_seq: Some(0),
+                before_seq: None,
+                limit: 200,
+            },
+        )
+        .await
+        .expect("read events");
+
+    let recovery_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.event_type == "drift_recovery_attempted")
+        .collect();
+    assert_eq!(
+        recovery_events.len(),
+        1,
+        "recovery must fire exactly once for the single drift event"
+    );
+    assert_eq!(recovery_events[0].level, AgentRunEventLevel::Warn);
+    assert_eq!(recovery_events[0].payload["attempt"], 1);
+    assert_eq!(recovery_events[0].payload["maxAttempts"], 1);
+    assert_eq!(recovery_events[0].payload["committedCount"], 1);
+
+    // The commit must NOT be rolled back when recovery succeeds.
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.event_type == "run_rollback_targets"),
+        "no rollback target events when recovery succeeds"
+    );
+    // The corrective nudge must reach the model — verify the message
+    // list grew with both the drifted assistant turn and our synthetic
+    // user reminder before round 4. The 4th model request should have
+    // received them.
+    let requests = model_gateway.requests().await;
+    assert_eq!(
+        requests.len(),
+        4,
+        "model must be called exactly 4 times (3 normal + 1 recovery)"
+    );
+    let last_request = requests.last().unwrap();
+    let drift_user_message = last_request
+        .messages
+        .iter()
+        .rev()
+        .find(|m| matches!(m.role, AgentModelRole::User))
+        .expect("recovery nudge must be present as user message");
+    let nudge_text = drift_user_message
+        .parts
+        .iter()
+        .find_map(|part| match part {
+            AgentModelContentPart::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .unwrap_or("");
+    assert!(
+        nudge_text.contains("drift recovery attempt 1/1"),
+        "nudge must include attempt counter; got: {nudge_text}"
+    );
+    assert!(
+        nudge_text.contains("workspace_finish"),
+        "nudge must reference workspace_finish; got: {nudge_text}"
+    );
+}
+
+/// Issue #64: when the model drifts WITHOUT having committed anything,
+/// the loop still tries one corrective nudge (per user decision). On
+/// recovery the model proceeds normally.
+#[tokio::test]
+async fn foreground_run_recovers_from_no_commit_drift_with_nudge() {
+    let root = std::env::temp_dir().join(format!(
+        "tauritavern-agent-drift-recovery-nocommit-{}",
+        Uuid::new_v4().simple()
+    ));
+    let repository = Arc::new(FileAgentRepository::new(root.clone()));
+    let run = AgentRun {
+        id: "run_drift_recovery_nocommit_test".to_string(),
+        workspace_id: "chat_drift_recovery_nocommit_test".to_string(),
+        stable_chat_id: "stable_drift_recovery_nocommit_test".to_string(),
+        chat_ref: AgentChatRef::Character {
+            character_id: "Seraphina".to_string(),
+            file_name: "Seraphina.png".to_string(),
+        },
+        generation_type: "normal".to_string(),
+        profile_id: None,
+        persist_base_state_id: None,
+        presentation: AgentRunPresentation::Foreground,
+        status: AgentRunStatus::Created,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    repository.create_run(&run).await.expect("create run");
+
+    let model_gateway = Arc::new(MockAgentModelGateway::new(vec![
+        // Round 1: drift right away — no tool calls.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Sure, here is the answer directly...",
+                }
+            }]
+        }),
+        // Round 2: model recovers and writes a file.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_write_nocommit",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_write_file",
+                            "arguments": "{\"path\":\"output/main.md\",\"content\":\"nudge worked\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 3: commit.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_commit_nocommit",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_commit",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        // Round 4: finish.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_finish_nocommit",
+                        "type": "function",
+                        "function": {
+                            "name": "workspace_finish",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+    ]));
+
+    let service = Arc::new(AgentRuntimeService::new(
+        repository.clone(),
+        repository.clone(),
+        repository.clone(),
+        test_chat_repository(&root),
+        test_chat_repository(&root),
+        test_skill_service(&root),
+        model_gateway.clone(),
+        test_profile_service(&root),
+    ));
+    let request = ChatCompletionGenerateRequestDto {
+        payload: json!({
+            "chat_completion_source": "openai",
+            "model": "test-model",
+            "messages": prompt_messages("no-commit drift recovery")
+        })
+        .as_object()
+        .cloned()
+        .unwrap(),
+    };
+    let prompt_snapshot = json!({ "chatCompletionPayload": request.payload.clone() });
+    let (_cancel_sender, mut cancel_receiver) = watch::channel(false);
+    let mut profile = test_resolved_profile(&root).await;
+    profile.run.presentation = AgentRunPresentation::Foreground;
+
+    let resolver = tokio::spawn(resolve_next_chat_commit(
+        service.clone(),
+        repository.clone(),
+        run.id.clone(),
+        "message_nocommit_42",
+    ));
+    service
+        .execute_agent_loop_run_inner(
+            &run.id,
+            prompt_snapshot,
+            request,
+            profile,
+            &mut cancel_receiver,
+        )
+        .await
+        .expect("recovery should let the run complete");
+    resolver.await.expect("resolver task");
+
+    let saved = repository.load_run(&run.id).await.expect("load run");
+    assert_eq!(saved.status, AgentRunStatus::Completed);
+
+    let events = repository
+        .read_events(
+            &run.id,
+            AgentRunEventReadQuery {
+                after_seq: Some(0),
+                before_seq: None,
+                limit: 200,
+            },
+        )
+        .await
+        .expect("read events");
+    let recovery_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.event_type == "drift_recovery_attempted")
+        .collect();
+    assert_eq!(recovery_events.len(), 1);
+    assert_eq!(recovery_events[0].payload["committedCount"], 0);
+
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.event_type == "run_rollback_targets"),
+        "no rollback when no commits existed before recovery"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/application/services/agent_runtime_service/tests.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/tests.rs
@@ -1126,16 +1126,20 @@ async fn foreground_run_commits_chat_message_before_finish() {
     tokio::fs::remove_dir_all(root).await.expect("cleanup");
 }
 
-/// Issue #55 + #64: when the model commits, then drifts by replying with
-/// plain text (no tool calls), the run gives the model **one** corrective
-/// nudge (issue #64 soft drift recovery). If it drifts AGAIN, the run
-/// must fail AND emit a `run_rollback_targets` event listing the
-/// now-orphaned chat message so the host UI can roll it back and offer
-/// the user a clean Retry. This is the failure-after-recovery path; the
-/// success path is covered by
-/// [`foreground_run_recovers_from_post_commit_drift_with_nudge`].
+/// Issue #55 + #64 + #69: when the model commits, then drifts by
+/// replying with plain text (no tool calls), the run gives the model
+/// **one** corrective nudge (issue #64 soft drift recovery). If it
+/// drifts AGAIN after the nudge, issue #69 prefers preserving the
+/// committed work over rolling it back: the loop soft-falls-back to
+/// `finish_run`, the chat message stays, and the run is marked
+/// `Completed` with a `drift_soft_finished` warning event so the host
+/// UI can flag the run as "completed with warnings".
+///
+/// The hard-fail path (no commits to preserve → still hard fail with
+/// `run_rollback_targets`) is covered by
+/// [`foreground_run_hard_fails_when_no_commit_to_preserve`].
 #[tokio::test]
-async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
+async fn foreground_run_soft_finishes_when_drift_recovery_exhausts_after_commit() {
     let root = std::env::temp_dir().join(format!(
         "tauritavern-agent-drift-rollback-{}",
         Uuid::new_v4().simple()
@@ -1250,6 +1254,172 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
         run.id.clone(),
         "message_42",
     ));
+    service
+        .execute_agent_loop_run_inner(
+            &run.id,
+            prompt_snapshot,
+            request,
+            profile,
+            &mut cancel_receiver,
+        )
+        .await
+        .expect("soft fallback must let the run complete cleanly");
+    resolver.await.expect("resolver task");
+
+    // #69: the run must complete (not fail) because a committed chat
+    // message exists. The model misbehaved, but throwing the chat away
+    // is worse than letting the user see it with a warning.
+    let saved = repository.load_run(&run.id).await.expect("load run");
+    assert_eq!(saved.status, AgentRunStatus::Completed);
+
+    let events = repository
+        .read_events(
+            &run.id,
+            AgentRunEventReadQuery {
+                after_seq: Some(0),
+                before_seq: None,
+                limit: 200,
+            },
+        )
+        .await
+        .expect("read events");
+
+    // #64 regression guard: exactly one `drift_recovery_attempted`
+    // event must precede the soft completion. If this assertion fails
+    // it means recovery was bypassed entirely.
+    let recovery_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.event_type == "drift_recovery_attempted")
+        .collect();
+    assert_eq!(
+        recovery_events.len(),
+        1,
+        "exactly one drift_recovery_attempted event must precede the soft finish"
+    );
+    assert_eq!(recovery_events[0].level, AgentRunEventLevel::Warn);
+    assert_eq!(recovery_events[0].payload["attempt"], 1);
+    assert_eq!(recovery_events[0].payload["maxAttempts"], 1);
+    assert_eq!(recovery_events[0].payload["committedCount"], 1);
+    assert_eq!(
+        recovery_events[0].payload["reasonCode"],
+        "model.tool_call_required"
+    );
+
+    // #69: after recovery exhausts, the loop must emit
+    // `drift_soft_finished` with the preserved commit, NOT
+    // `run_rollback_targets`. The host UI uses this to render a
+    // "completed with warnings" badge.
+    let soft_finished = events
+        .iter()
+        .find(|event| event.event_type == "drift_soft_finished")
+        .expect("drift_soft_finished event must be emitted instead of rollback");
+    assert_eq!(soft_finished.level, AgentRunEventLevel::Warn);
+    assert_eq!(
+        soft_finished.payload["reasonCode"],
+        "model.tool_call_required"
+    );
+    assert_eq!(soft_finished.payload["preservedCommitCount"], 1);
+    let preserved = soft_finished.payload["preservedCommits"]
+        .as_array()
+        .expect("preservedCommits array");
+    assert_eq!(preserved.len(), 1);
+    assert_eq!(preserved[0]["messageId"], "message_42");
+    assert_eq!(preserved[0]["path"], "output/main.md");
+
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.event_type == "run_rollback_targets"),
+        "#69 soft fallback must not emit rollback when commits exist"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.event_type == "run_completed"),
+        "run_completed must follow drift_soft_finished"
+    );
+}
+
+/// Issue #69 inverse case: when the model drifts and there is **no**
+/// committed work to preserve, the loop must still hard-fail with the
+/// original `model.tool_call_required` error so the user notices the
+/// run never produced a deliverable. The soft fallback only kicks in
+/// when there is something to preserve.
+#[tokio::test]
+async fn foreground_run_hard_fails_when_drift_recovery_exhausts_without_commit() {
+    let root = std::env::temp_dir().join(format!(
+        "tauritavern-agent-drift-hardfail-{}",
+        Uuid::new_v4().simple()
+    ));
+    let repository = Arc::new(FileAgentRepository::new(root.clone()));
+    let run = AgentRun {
+        id: "run_drift_hardfail_test".to_string(),
+        workspace_id: "chat_drift_hardfail_test".to_string(),
+        stable_chat_id: "stable_drift_hardfail_test".to_string(),
+        chat_ref: AgentChatRef::Character {
+            character_id: "Seraphina".to_string(),
+            file_name: "Seraphina.png".to_string(),
+        },
+        generation_type: "normal".to_string(),
+        profile_id: None,
+        persist_base_state_id: None,
+        presentation: AgentRunPresentation::Foreground,
+        status: AgentRunStatus::Created,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    repository.create_run(&run).await.expect("create run");
+
+    let model_gateway = Arc::new(MockAgentModelGateway::new(vec![
+        // Round 1: model drifts immediately — plain text, no tool calls,
+        // no prior commit. #64 still gets one recovery attempt.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "I'll just answer directly without using any tools.",
+                }
+            }]
+        }),
+        // Round 2: model ignores the nudge and drifts again. Recovery
+        // budget exhausted AND no commit to preserve → hard fail with
+        // `run_rollback_targets` (empty target list) so the host UI can
+        // still surface the error for the user.
+        json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Still answering directly, sorry.",
+                }
+            }]
+        }),
+    ]));
+
+    let service = Arc::new(AgentRuntimeService::new(
+        repository.clone(),
+        repository.clone(),
+        repository.clone(),
+        test_chat_repository(&root),
+        test_chat_repository(&root),
+        test_skill_service(&root),
+        model_gateway,
+        test_profile_service(&root),
+    ));
+    let request = ChatCompletionGenerateRequestDto {
+        payload: json!({
+            "chat_completion_source": "openai",
+            "model": "test-model",
+            "messages": prompt_messages("drift with no commit")
+        })
+        .as_object()
+        .cloned()
+        .unwrap(),
+    };
+    let prompt_snapshot = json!({ "chatCompletionPayload": request.payload.clone() });
+    let (_cancel_sender, mut cancel_receiver) = watch::channel(false);
+    let mut profile = test_resolved_profile(&root).await;
+    profile.run.presentation = AgentRunPresentation::Foreground;
+
     let outcome = service
         .execute_agent_loop_run_inner(
             &run.id,
@@ -1259,11 +1429,11 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
             &mut cancel_receiver,
         )
         .await;
-    resolver.await.expect("resolver task");
 
+    let error = outcome.expect_err("no-commit drift after recovery must hard-fail");
     assert!(
-        outcome.is_err(),
-        "drift after commit must fail the run, got Ok"
+        error.to_string().contains("model.tool_call_required"),
+        "unexpected error: {error}"
     );
 
     let events = repository
@@ -1278,42 +1448,20 @@ async fn foreground_run_emits_rollback_targets_on_tool_call_required_drift() {
         .await
         .expect("read events");
 
-    // #64: the first drift must have produced exactly one
-    // `drift_recovery_attempted` event before we surrendered to the
-    // rollback path. If this assertion fails it means the rollback was
-    // emitted on the first drift (recovery was bypassed) — a regression
-    // of #64.
-    let recovery_events: Vec<_> = events
+    // Recovery must still be attempted exactly once.
+    let recovery_count = events
         .iter()
         .filter(|event| event.event_type == "drift_recovery_attempted")
-        .collect();
-    assert_eq!(
-        recovery_events.len(),
-        1,
-        "exactly one drift_recovery_attempted event must precede the rollback"
-    );
-    assert_eq!(recovery_events[0].level, AgentRunEventLevel::Warn);
-    assert_eq!(recovery_events[0].payload["attempt"], 1);
-    assert_eq!(recovery_events[0].payload["maxAttempts"], 1);
-    assert_eq!(recovery_events[0].payload["committedCount"], 1);
-    assert_eq!(
-        recovery_events[0].payload["reasonCode"],
-        "model.tool_call_required"
-    );
+        .count();
+    assert_eq!(recovery_count, 1);
 
-    let rollback = events
-        .iter()
-        .find(|event| event.event_type == "run_rollback_targets")
-        .expect("run_rollback_targets event must be emitted on drift after commit");
-    assert_eq!(rollback.level, AgentRunEventLevel::Warn);
-    assert_eq!(rollback.payload["reasonCode"], "model.tool_call_required");
-    assert_eq!(rollback.payload["targetCount"], 1);
-    let targets = rollback.payload["targets"]
-        .as_array()
-        .expect("targets array");
-    assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0]["messageId"], "message_42");
-    assert_eq!(targets[0]["path"], "output/main.md");
+    // Soft finish must NOT fire because there is no commit to preserve.
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.event_type == "drift_soft_finished"),
+        "soft fallback must not fire when there is nothing to preserve"
+    );
 }
 
 /// Issue #64: when the model commits and then drifts (plain text, no

--- a/src-tauri/src/application/services/agent_runtime_service/tool_execution.rs
+++ b/src-tauri/src/application/services/agent_runtime_service/tool_execution.rs
@@ -44,23 +44,22 @@ impl AgentRuntimeService {
         let started = Instant::now();
 
         if self.tool_registry.spec_by_name(&call.name).is_none() {
-            let error = ApplicationError::ValidationError(format!(
-                "model.unknown_tool_call: model requested unknown Agent tool `{}`",
-                call.name
-            ));
-            self.event(
-                run_id,
-                AgentRunEventLevel::Error,
-                "tool_call_failed",
-                json!({
-                    "round": round,
-                    "callId": call.id.as_str(),
-                    "name": call.name.as_str(),
-                    "message": error.to_string(),
-                }),
-            )
-            .await?;
-            return Err(error);
+            // Issue #69: previously this hard-failed the run with
+            // `model.unknown_tool_call`. That throws away any earlier work
+            // when the model only made a typo. Convert it to a recoverable
+            // tool error so the next turn the model sees the typo and can
+            // retry with a valid tool name.
+            let outcome = recoverable_tool_error(
+                call,
+                "model.unknown_tool_call",
+                &format!(
+                    "Unknown Agent tool `{}`. Pick from the tools listed in the request schema.",
+                    call.name
+                ),
+                started.elapsed().as_millis(),
+            );
+            self.record_tool_outcome(run_id, round, &outcome).await?;
+            return Ok(outcome);
         }
 
         if !tool_is_visible(profile, call.name.as_str()) {
@@ -158,6 +157,34 @@ impl AgentRuntimeService {
                 Ok(outcome)
             }
             Err(error) => {
+                // Issue #69: convert recoverable dispatch errors into a
+                // tool-error result so the model can see what went wrong
+                // and try again, rather than tearing down the whole run.
+                // We keep infrastructure / cancellation errors as hard
+                // failures because they aren't something the model can
+                // fix from inside the tool loop.
+                let elapsed_ms = started.elapsed().as_millis();
+                if let Some((code, detail)) =
+                    classify_dispatch_error_for_model(&error, call.name.as_str())
+                {
+                    self.event(
+                        run_id,
+                        AgentRunEventLevel::Warn,
+                        "tool_dispatch_soft_recovered",
+                        json!({
+                            "round": round,
+                            "callId": call.id.as_str(),
+                            "name": call.name.as_str(),
+                            "code": code,
+                            "message": detail,
+                        }),
+                    )
+                    .await?;
+                    let outcome =
+                        recoverable_tool_error(call, code, detail.as_str(), elapsed_ms);
+                    self.record_tool_outcome(run_id, round, &outcome).await?;
+                    return Ok(outcome);
+                }
                 self.event(
                     run_id,
                     AgentRunEventLevel::Error,
@@ -284,6 +311,74 @@ fn hex_encode(bytes: &[u8]) -> String {
 fn tool_is_visible(profile: &ResolvedAgentProfile, name: &str) -> bool {
     profile.tools.allow.iter().any(|allowed| allowed == name)
         && !profile.tools.deny.iter().any(|denied| denied == name)
+}
+
+/// Decide whether a dispatch-time `ApplicationError` is something the
+/// model could plausibly fix on a retry. If yes, return the
+/// (code, detail) pair we should feed back into the tool loop as a
+/// recoverable tool error; if no, return `None` so the caller keeps the
+/// existing fail-fast behavior.
+///
+/// We are deliberately conservative:
+///
+/// * `ValidationError` and `NotFound` are model-facing — they typically
+///   originate from arg parsing, path parsing, or repository lookups for
+///   resources the model named. The model can fix all three on its own.
+/// * `RateLimited` and `Transient` are also surfaced so the model can,
+///   say, fall back to a smaller search query. They are also auto-retried
+///   higher up, but a tool-result with the code is a useful signal.
+/// * `InternalError`, `PermissionDenied`, `Unauthorized`, `Cancelled` keep
+///   the original hard-fail behavior — those mean the host or
+///   infrastructure has decided this run cannot proceed.
+fn classify_dispatch_error_for_model(
+    error: &ApplicationError,
+    tool_name: &str,
+) -> Option<(&'static str, String)> {
+    match error {
+        ApplicationError::ValidationError(message) => {
+            Some((classify_tool_error_code(message), message.clone()))
+        }
+        ApplicationError::NotFound(message) => Some(("tool.not_found", message.clone())),
+        ApplicationError::RateLimited(message) => {
+            Some(("tool.rate_limited", message.clone()))
+        }
+        ApplicationError::Transient(message) => Some(("tool.transient", message.clone())),
+        ApplicationError::InternalError(_)
+        | ApplicationError::PermissionDenied(_)
+        | ApplicationError::Unauthorized(_)
+        | ApplicationError::Cancelled(_) => {
+            let _ = tool_name;
+            None
+        }
+    }
+}
+
+/// Extract a structured `tool.*` style error code from a validation
+/// error message when the tool layer encoded one (e.g.
+/// `workspace.invalid_path: ...`). Falls back to a generic
+/// `tool.invalid_call` so the model always sees a deterministic code.
+fn classify_tool_error_code(message: &str) -> &'static str {
+    let trimmed = message.trim();
+    let Some((prefix, _)) = trimmed.split_once(':') else {
+        return "tool.invalid_call";
+    };
+    let prefix = prefix.trim();
+    if prefix.contains('.')
+        && prefix
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        match prefix {
+            "workspace.invalid_path" => "workspace.invalid_path",
+            "workspace.path_is_directory" => "workspace.path_is_directory",
+            "workspace.file_not_found" => "workspace.file_not_found",
+            "workspace.invalid_args" => "workspace.invalid_args",
+            "model.unknown_tool_call" => "model.unknown_tool_call",
+            _ => "tool.invalid_call",
+        }
+    } else {
+        "tool.invalid_call"
+    }
 }
 
 fn recoverable_tool_error(


### PR DESCRIPTION
## TL;DR

#62 / #68 / #69 三者层层递进，**不重复**：

| | 解决什么 | 关联 issue |
|---|---|---|
| #62（已合） | drift 发生后告诉前端善后（rollback 信号 + userRetryable） | #54 + #55 |
| #68 | 减少 drift 发生概率 + drift 时给模型**一次自救** | #64 |
| **#69（本 PR）** | **自救失败 / 其它 drift / dispatch / persistent commit 失败时，只要已 commit 过 chat 就保留它** | #69 |

核心原则：**"已通过 `workspace.commit` 写出的工作绝不丢"。**

## 改了哪些 hard-fail 路径

| 失败场景 | 已 commit? | 旧行为 | 新行为 |
|---|---|---|---|
| Drift recovery（#68）耗尽 | 是 | rollback + run_failed | `drift_soft_finished` → finish → completed |
| `agent.tool_after_finish` | 是 | rollback + run_failed | 跳过多余调用 → finish → completed |
| `agent.max_tool_rounds_exceeded` | 是 | rollback + run_failed | `drift_soft_finished` → finish → completed |
| `finish_run` persistent commit 失败 | — | run_failed | warning（`softDegraded:true`）→ completed |
| 模型 typo 工具名 / dispatch 抛 ValidationError/NotFound/RateLimited/Transient | — | run_failed | 转 `recoverable_tool_error` 回填给模型自救 |

以上四类**无 commit** 时全部保持原 hard-fail 行为，防止 soft fallback 把真正的 profile 问题静默吞掉。`InternalError` / `PermissionDenied` / `Unauthorized` / `Cancelled` 仍硬失败（模型自己救不了）。

## 兼容性

- `run_rollback_targets` 监听器仍然有效，只是不再在"已 commit 的 drift 路径"触发；过渡期即使前端不改，至少**不会丢用户工作**。
- `run_failed` 形态不变，只在真正 hard-fail 路径上出现。
- 新事件 `drift_soft_finished` / `drift_soft_skipped_post_finish_tool` / `tool_dispatch_soft_recovered` 都是 additive，旧宿主忽略即可。

## 测试

- 改写原 #55 测试 → `foreground_run_soft_finishes_when_drift_recovery_exhausts_after_commit`（已 commit 时走软兜底）
- 新增 `foreground_run_hard_fails_when_drift_recovery_exhausts_without_commit`（无 commit 时锁死硬失败路径）
- Layer 1（dispatch soft-recover）由现有 `agent_loop_returns_recoverable_tool_errors_to_model` 隐式覆盖
- `cargo test --lib`：**602 passed / 0 failed**

## 改动量

| 文件 | 行数 |
|---|---|
| loop_runner.rs | +97 / -2 |
| tool_execution.rs | +112 / -17 |
| commit.rs | +30 / -16 |
| tests.rs | +184 / -28 |
| docs（RunEventJournal + ToolSystem） | +73 / -9 |

应用层 ~200 LOC 代码 + 测试和文档其余。Clean Architecture 仅 application 层、零跨层污染、零 domain 接口变更。

## 依赖

基于 #68（`feat/agent-drift-recovery`），建议先合 #68 再合本 PR。如果 #68 关掉，本 PR 会 rebase 到 `next/2.0.0` 重写为独立形态。