### PR TITLE
fix(chat): custom_* 附加参数字段容忍 JSON null

### DIFF
--- a/src-tauri/src/application/services/chat_completion_service/additional_parameters.rs
+++ b/src-tauri/src/application/services/chat_completion_service/additional_parameters.rs
@@ -88,6 +88,18 @@ fn optional_string(payload: &Map<String, Value>, key: &str) -> Result<String, Ap
         return Ok(String::new());
     };
 
+    // Treat JSON null the same as a missing field. Frontend presets and
+    // third-party extensions (e.g. per-chat API routers) can persist `null`
+    // into `custom_include_body` / `custom_exclude_body` / `custom_include_headers`
+    // when a slot was cleared, and our `/api/backends/chat-completions/generate`
+    // route forwards the body verbatim. Without this guard the upstream value
+    // surfaces as a confusing "must be a string" validation error even though
+    // the field is semantically absent, mirroring serde's `Option<String>`
+    // behaviour for nullable fields.
+    if value.is_null() {
+        return Ok(String::new());
+    }
+
     value.as_str().map(str::to_string).ok_or_else(|| {
         ApplicationError::ValidationError(format!(
             "Chat completion request field must be a string: {}",
@@ -146,6 +158,36 @@ mod tests {
             AdditionalParameters::from_payload(&payload).expect_err("field type should fail");
 
         assert!(error.to_string().contains("custom_include_body"));
+    }
+
+    #[test]
+    fn null_payload_fields_are_treated_as_missing() {
+        // Stale presets and third-party extensions sometimes persist a literal
+        // `null` for these slots; the HTTP boundary should accept that the same
+        // way a missing field would be accepted, instead of bubbling up a
+        // confusing "must be a string" validation error to the user.
+        let payload = json!({
+            "custom_include_body": null,
+            "custom_exclude_body": null,
+            "custom_include_headers": null,
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be an object");
+
+        let parameters = AdditionalParameters::from_payload(&payload)
+            .expect("null fields should be tolerated, not rejected as non-string");
+
+        // Empty defaults should remain after construction.
+        parameters
+            .ensure_body_overrides_do_not_touch(&["messages", "tools"])
+            .expect("absent overrides should never trip the protected-field guard");
+
+        let headers = parameters.headers().expect("headers should parse cleanly");
+        assert!(
+            headers.is_empty(),
+            "null include_headers must not produce any header entries",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 做了什么
`/api/backends/chat-completions/generate` 把请求体原样转发到 Rust，所以前端只要给 `custom_include_body` / `custom_exclude_body` / `custom_include_headers` 持久化了字面 `null`，Rust 端共用的 `optional_string` 就会拒掉，给用户看到一条比较迷惑的错：

> Failed to generate chat completion: Validation error: Chat completion request field must be a string: `custom_include_headers`

真实触发场景是这两类：用户清空过字段、被预设序列化成了字面 `null`；或者 per-chat API 路由类的第三方扩展塞了带 null 的稀疏 JSON。在语义上字段就是"没填"，老分支里"字段缺失"已经返回空串了，null 没理由跟它不一样。

## 改了什么
`optional_string` 加一句 `if value.is_null() { return Ok(String::new()); }`，三个 `custom_*` 字段共享同一个 helper 所以一起受益。新增单测 `null_payload_fields_are_treated_as_missing` 钉契约。

## 不影响什么
真正的类型错用（number / array / object）仍然 fail fast，原报错信息保留。

## 设计约束（contribution 规则核对）
单文件、单函数、单分支，没有 drive-by 重构；不新增 error 变体；前端不动——在 Rust HTTP 边界统一兜底，省得每个调用方（前端、移动端、自动化脚本、扩展）各自再实现一遍 `String(... || '')`。

## 验证
- `cargo check --tests` 干净。
- `cargo test --lib` **787 passed**。