### PR TITLE
fix(chat): accept object/array custom_* override fields

### DIFF
--- a/src-tauri/src/application/services/chat_completion_service/additional_parameters.rs
+++ b/src-tauri/src/application/services/chat_completion_service/additional_parameters.rs
@@ -88,24 +88,39 @@ fn optional_string(payload: &Map<String, Value>, key: &str) -> Result<String, Ap
         return Ok(String::new());
     };
 
-    // Treat JSON null the same as a missing field. Frontend presets and
-    // third-party extensions (e.g. per-chat API routers) can persist `null`
-    // into `custom_include_body` / `custom_exclude_body` / `custom_include_headers`
-    // when a slot was cleared, and our `/api/backends/chat-completions/generate`
-    // route forwards the body verbatim. Without this guard the upstream value
-    // surfaces as a confusing "must be a string" validation error even though
-    // the field is semantically absent, mirroring serde's `Option<String>`
-    // behaviour for nullable fields.
-    if value.is_null() {
-        return Ok(String::new());
-    }
-
-    value.as_str().map(str::to_string).ok_or_else(|| {
+    coerce_custom_parameter_field(value).ok_or_else(|| {
         ApplicationError::ValidationError(format!(
             "Chat completion request field must be a string: {}",
             key
         ))
     })
+}
+
+/// Normalizes a custom override field (`custom_include_headers`,
+/// `custom_include_body`, `custom_exclude_body`) into the string form expected by
+/// [`custom_parameters`].
+///
+/// SillyTavern's frontend always serializes these fields to a YAML/JSON *string*,
+/// and our `/api/backends/chat-completions/generate` route forwards the body
+/// verbatim. However the wire value is not always a string:
+///
+/// - `null` — stale presets / per-chat API routers persist a literal `null` when
+///   a slot is cleared. Treated the same as a missing field.
+/// - object / array — some third-party extensions (e.g. ST-Memory-Context) inject
+///   auth headers as a native JSON object, e.g.
+///   `custom_include_headers: { "Authorization": "Bearer …" }`. Upstream tolerates
+///   this through `mergeObjectWithYaml`, so we serialize the structured value back
+///   into a JSON string (which `parse_object` already understands) instead of
+///   rejecting the request with a confusing "must be a string" error.
+///
+/// Other scalar types (numbers, booleans) remain invalid.
+pub(super) fn coerce_custom_parameter_field(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => Some(String::new()),
+        Value::String(text) => Some(text.clone()),
+        Value::Object(_) | Value::Array(_) => Some(value.to_string()),
+        _ => None,
+    }
 }
 
 fn protected_body_override_error(key: &str) -> ApplicationError {
@@ -146,7 +161,35 @@ mod tests {
     }
 
     #[test]
-    fn non_string_payload_fields_fail_fast() {
+    fn object_form_include_headers_are_coerced_to_string() {
+        // ST-Memory-Context injects auth via a native JSON object instead of a
+        // YAML/JSON string. The field must be accepted and parsed into headers.
+        let payload = json!({
+            "custom_include_headers": {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer secret-token"
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be an object");
+
+        let parameters = AdditionalParameters::from_payload(&payload)
+            .expect("object-form headers should be accepted");
+        let headers = parameters.headers().expect("headers should parse");
+
+        assert_eq!(
+            headers.get("Authorization"),
+            Some(&"Bearer secret-token".to_string())
+        );
+        assert_eq!(
+            headers.get("Content-Type"),
+            Some(&"application/json".to_string())
+        );
+    }
+
+    #[test]
+    fn object_form_include_body_is_coerced_and_applied() {
         let payload = json!({
             "custom_include_body": { "temperature": 0.7 }
         })
@@ -154,10 +197,30 @@ mod tests {
         .cloned()
         .expect("payload must be an object");
 
-        let error =
-            AdditionalParameters::from_payload(&payload).expect_err("field type should fail");
+        let parameters = AdditionalParameters::from_payload(&payload)
+            .expect("object-form body override should be accepted");
+        let mut upstream_payload = json!({ "model": "gpt-4.1-mini", "temperature": 0.1 });
 
-        assert!(error.to_string().contains("custom_include_body"));
+        parameters
+            .apply_body_overrides(&mut upstream_payload)
+            .expect("overrides should apply");
+
+        assert_eq!(upstream_payload["temperature"], json!(0.7));
+    }
+
+    #[test]
+    fn scalar_payload_fields_fail_fast() {
+        // Numbers / booleans cannot represent a header or body map and must still
+        // be rejected so genuine client bugs surface instead of being swallowed.
+        let payload = json!({ "custom_include_headers": 42 })
+            .as_object()
+            .cloned()
+            .expect("payload must be an object");
+
+        let error =
+            AdditionalParameters::from_payload(&payload).expect_err("numeric field should fail");
+
+        assert!(error.to_string().contains("custom_include_headers"));
     }
 
     #[test]

--- a/src-tauri/src/application/services/chat_completion_service/mod.rs
+++ b/src-tauri/src/application/services/chat_completion_service/mod.rs
@@ -184,12 +184,14 @@ impl ChatCompletionService {
                 continue;
             };
 
-            let value = value.as_str().ok_or_else(|| {
-                ApplicationError::ValidationError(format!(
-                    "Chat completion request field must be a string: {}",
-                    key
-                ))
-            })?;
+            let value = additional_parameters::coerce_custom_parameter_field(value).ok_or_else(
+                || {
+                    ApplicationError::ValidationError(format!(
+                        "Chat completion request field must be a string: {}",
+                        key
+                    ))
+                },
+            )?;
 
             if !value.trim().is_empty() {
                 overridden.push(key);


### PR DESCRIPTION
## 问题

通过插件内置 API 代理（如 [ST-Memory-Context](https://github.com/gaigai315/ST-Memory-Context)）发起生成时，后端报错：

```
Failed to generate chat completion: Validation error: Chat completion request field must be a string: custom_include_headers
```

而不发送该字段的插件（如 [SillyTavern-Horae](https://github.com/baibai-git/SillyTavern-Horae)）则不受影响。

## 根因

`/api/backends/chat-completions/generate`（及 stream）会把请求体原样转发给后端，后端 `AdditionalParameters::from_payload` 要求 `custom_include_headers` / `custom_include_body` / `custom_exclude_body` **必须是字符串**。

但 ST-Memory-Context 把鉴权头作为**原生 JSON 对象**注入：

```js
custom_include_headers: { "Content-Type": "application/json" }
// ...
proxyPayload.custom_include_headers["Authorization"] = authHeader;
```

后端遇到对象直接抛出 `ValidationError`。上游 SillyTavern 通过 `mergeObjectWithYaml` 对非字符串是容忍的，所以同样的插件在上游不会崩。

> 之前合入的 PR 只加了 `null` 容错，没覆盖对象/数组这种情况。

## 改动

将 `optional_string` 里已有的 `null` 容错抽成共享 helper `coerce_custom_parameter_field`：

- `String` → 原样使用
- `null` → 视为缺省（空串）
- object / array → 序列化为 JSON 字符串（底层 `parse_object` 本就支持 JSON，等价 YAML 超集）
- 其他标量（数字/布尔）→ 仍然 fail-fast

这样不仅修复崩溃，还能**正确地把对象形式的 header 注入**进去（而非像上游那样静默丢弃）。iOS endpoint-override 校验路径复用同一 helper 保持一致。

仅改动 `chat_completion_service` 内 2 个文件，符合「最小改动范围 / 不动 vendor」约定。

## Test plan

- [ ] `cd src-tauri && cargo test --lib chat_completion_service::additional_parameters`
- [ ] `cd src-tauri && cargo check --tests`
- [ ] 用 ST-Memory-Context 内置 API 代理实际发起一次生成，确认不再报 `must be a string` 且 Authorization 头生效

新增/调整的单测覆盖：对象形式 headers 被解析为正确 header、对象形式 body override 被应用、纯标量仍 fail-fast、`null` 仍视为缺省。

Made with [Cursor](https://cursor.com)