### PR TITLE
fix(chat): strip functionCall.id from Gemini requests

### DIFF
--- a/src-tauri/src/application/services/chat_completion_service/payload/makersuite.rs
+++ b/src-tauri/src/application/services/chat_completion_service/payload/makersuite.rs
@@ -445,6 +445,8 @@ fn convert_messages(
             }
         }
 
+        strip_function_call_ids(&mut parts);
+
         contents.push(json!({
             "role": target_role,
             "parts": parts,
@@ -452,6 +454,24 @@ fn convert_messages(
     }
 
     (contents, system_parts.join("\n\n"))
+}
+
+/// Gemini's `generateContent` request API rejects an `id` field inside
+/// `functionCall` parts (`Unknown name "id" at '…parts[N].function_call'`),
+/// even though Gemini *responses* return one. Native parts are echoed back
+/// verbatim on tool-call turns, so strip the response-only `id` before the
+/// part is sent upstream. The id is still preserved in the normalized
+/// `tool_calls`, and Gemini pairs `functionResponse` by `name`, not id.
+fn strip_function_call_ids(parts: &mut [Value]) {
+    for part in parts.iter_mut() {
+        if let Some(function_call) = part
+            .as_object_mut()
+            .and_then(|object| object.get_mut("functionCall"))
+            .and_then(Value::as_object_mut)
+        {
+            function_call.remove("id");
+        }
+    }
 }
 
 fn convert_message_content_to_parts(content: Option<&Value>, is_gemini3: bool) -> Vec<Value> {
@@ -1199,6 +1219,70 @@ mod tests {
             .unwrap_or_default();
 
         assert_eq!(thought_signature, "sig_1");
+    }
+
+    #[test]
+    fn makersuite_strips_function_call_id_from_replayed_native_parts() {
+        // Gemini responses return `functionCall.id`, which we persist verbatim in
+        // `native.gemini`. The request API rejects that `id`, so it must be
+        // stripped before the assistant turn is echoed back.
+        let payload = json!({
+            "model": "gemini-3-pro",
+            "messages": [
+                {"role": "user", "content": "weather?"},
+                {
+                    "role": "assistant",
+                    "content": "checking",
+                    "tool_calls": [{
+                        "id": "call_weather",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": "{\"city\":\"Paris\"}"}
+                    }],
+                    "native": {
+                        "gemini": {
+                            "content": {
+                                "role": "model",
+                                "parts": [{
+                                    "functionCall": {
+                                        "name": "weather",
+                                        "args": {"city": "Paris"},
+                                        "id": "call_weather"
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                },
+                {"role": "tool", "tool_call_id": "call_weather", "content": "{\"temperature\":20}"}
+            ]
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload).expect("build should succeed");
+        let body = upstream.as_object().expect("body must be object");
+        let function_call = body
+            .get("contents")
+            .and_then(Value::as_array)
+            .and_then(|contents| contents.get(1))
+            .and_then(Value::as_object)
+            .and_then(|content| content.get("parts"))
+            .and_then(Value::as_array)
+            .and_then(|parts| parts.first())
+            .and_then(Value::as_object)
+            .and_then(|part| part.get("functionCall"))
+            .and_then(Value::as_object)
+            .expect("assistant functionCall part must exist");
+
+        assert!(
+            function_call.get("id").is_none(),
+            "functionCall.id must be stripped from the Gemini request"
+        );
+        assert_eq!(
+            function_call.get("name").and_then(Value::as_str),
+            Some("weather")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景 / 问题

通过 Gemini（makersuite / vertexai）跑带工具调用的 agent 时，第二轮回放会报：

> Validation error: Invalid JSON payload received. Unknown name "id" at 'contents[N].parts[M].function_call'

导致工具调用循环（含子 agent）中断。

## 根因

1. Gemini 响应里的 `functionCall` 带 `id`（Gemini 3 尤甚）。归一化器读取该 id 用于匹配，同时把整段候选 `content` 原样存入 `native.gemini`（`normalizers.rs`）。
2. 下一轮 `encode.rs::copy_native_continuation` 把 `native.gemini` 原样塞回消息，`makersuite.rs::message_native_gemini_parts` 又原样取出当请求体 parts。
3. Gemini 的 `generateContent` **请求**端不接受 `functionCall.id`（只在响应里返回），于是被拒。

核心矛盾：Gemini 响应的 functionCall 带 id，但请求的 functionCall 不允许 id，而我们原样回放了。

## 修复

在 `payload/makersuite.rs` 构建每条消息发往 Gemini 的 parts 出口处，统一剥掉 `functionCall.id`（`strip_function_call_ids`）。一处出口覆盖原生回放、content 透传、工具调用三条路径，且 makersuite 与 vertexai 共用 `convert_messages`，两种来源都生效。

## 为什么安全

- `functionCall.id` 本就只存在于响应、请求端不接受，删除是符合 Gemini 契约的。
- id 仍保留在归一化的 `tool_calls` 里做内部记账。
- Gemini 的 `functionResponse` 靠 `name` 配对，不靠 id，故工具调用/结果配对不受影响。

## 改动符合的约定

- **分层**：只在请求构建器（application 层 payload 出口）做 Gemini 请求格式清洗，不改归一化存储，依赖方向不变。
- **最小改动**：单文件、纯新增，无无关重构。
- **测试就近**：新增回归测试 `makersuite_strips_function_call_id_from_replayed_native_parts`，模拟带 id 的原生 Gemini functionCall 回放，断言请求里 id 被剥、name 保留。

## Test plan

- [ ] `cd src-tauri && cargo test --lib makersuite`
- [ ] 实机：用 Gemini 模型跑一次含工具调用的多轮 agent，确认不再报 `Unknown name "id" ... function_call`

Made with [Cursor](https://cursor.com)