### PR TITLE
fix(chat): normalize OpenRouter reasoning effort

### DIFF
--- a/src-tauri/src/application/services/chat_completion_service/payload/openai_reasoning.rs
+++ b/src-tauri/src/application/services/chat_completion_service/payload/openai_reasoning.rs
@@ -46,6 +46,18 @@ pub(super) fn normalize_openai_reasoning_effort<'a>(
     value: &'a str,
     model: &str,
 ) -> Option<Cow<'a, str>> {
+    normalize_reasoning_effort(value, supports_openai_xhigh_reasoning_effort(model))
+}
+
+/// Maps SillyTavern's reasoning-effort preset values onto the provider enum
+/// (`xhigh`/`high`/`medium`/`low`/`minimal`/`none`). `auto` is dropped (let the
+/// model decide), `min`→`minimal`, `max`/`maximum`→`high`. `xhigh` is preserved
+/// only when `allow_xhigh` is set, otherwise it is downgraded to `high`.
+///
+/// Callers decide `allow_xhigh`: OpenAI gates it on the GPT model version, while
+/// providers that accept `xhigh` for the routed model (e.g. OpenRouter Claude)
+/// pass `true` so the level is not silently downgraded.
+pub(super) fn normalize_reasoning_effort(value: &str, allow_xhigh: bool) -> Option<Cow<'_, str>> {
     let value = value.trim();
     if value.is_empty() || value.eq_ignore_ascii_case("auto") {
         return None;
@@ -58,13 +70,7 @@ pub(super) fn normalize_openai_reasoning_effort<'a>(
         return Some(Cow::Borrowed("high"));
     }
     if value.eq_ignore_ascii_case("xhigh") {
-        return Some(Cow::Borrowed(
-            if supports_openai_xhigh_reasoning_effort(model) {
-                "xhigh"
-            } else {
-                "high"
-            },
-        ));
+        return Some(Cow::Borrowed(if allow_xhigh { "xhigh" } else { "high" }));
     }
 
     Some(Cow::Borrowed(value))

--- a/src-tauri/src/application/services/chat_completion_service/payload/openrouter.rs
+++ b/src-tauri/src/application/services/chat_completion_service/payload/openrouter.rs
@@ -1,6 +1,7 @@
 use serde_json::{Map, Value, json};
 
 use super::openai;
+use super::openai_reasoning::normalize_openai_reasoning_effort;
 use super::shared::insert_if_present;
 
 pub(super) fn build(payload: Map<String, Value>) -> (String, Value) {
@@ -53,18 +54,29 @@ fn apply_openrouter_overrides(body: &mut Map<String, Value>, source_payload: &Ma
         body.insert("route".to_string(), Value::String("fallback".to_string()));
     }
 
+    // OpenRouter validates `reasoning.effort` against a fixed enum
+    // (xhigh|high|medium|low|minimal|none) and rejects SillyTavern's `max`/`auto`
+    // preset values. Normalize through the shared helper like the other builders
+    // (max -> high, min -> minimal, auto -> omitted, xhigh per model) instead of
+    // forwarding the raw value. Remove the flat field unconditionally so the raw
+    // value never leaks alongside the nested `reasoning` object.
+    body.remove("reasoning_effort");
     if let Some(reasoning_effort) = source_payload
         .get("reasoning_effort")
         .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+        .and_then(|value| {
+            normalize_openai_reasoning_effort(
+                value,
+                source_payload
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .unwrap_or(""),
+            )
+        })
     {
-        body.remove("reasoning_effort");
         body.insert(
             "reasoning".to_string(),
-            json!({
-                "effort": reasoning_effort,
-            }),
+            json!({ "effort": reasoning_effort.as_ref() }),
         );
     }
 }
@@ -169,6 +181,52 @@ mod tests {
             transforms.first().and_then(Value::as_str),
             Some("middle-out")
         );
+    }
+
+    #[test]
+    fn openrouter_normalizes_max_reasoning_effort_to_high() {
+        // SillyTavern's `max` preset is not in OpenRouter's effort enum; it must be
+        // normalized to `high` rather than forwarded raw (which OpenRouter rejects).
+        let payload = json!({
+            "chat_completion_source": "openrouter",
+            "model": "openai/gpt-5.1",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "max"
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload);
+        assert_eq!(
+            upstream.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("high")
+        );
+        assert!(
+            upstream
+                .as_object()
+                .and_then(|body| body.get("reasoning_effort"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn openrouter_omits_auto_reasoning_effort() {
+        let payload = json!({
+            "chat_completion_source": "openrouter",
+            "model": "openai/gpt-5.1",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "auto"
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload);
+        let body = upstream.as_object().expect("payload must be object");
+
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/src-tauri/src/application/services/chat_completion_service/payload/openrouter.rs
+++ b/src-tauri/src/application/services/chat_completion_service/payload/openrouter.rs
@@ -1,7 +1,8 @@
 use serde_json::{Map, Value, json};
 
+use super::super::prompt_caching_plan::is_openrouter_claude_model_name;
 use super::openai;
-use super::openai_reasoning::normalize_openai_reasoning_effort;
+use super::openai_reasoning::{normalize_openai_reasoning_effort, normalize_reasoning_effort};
 use super::shared::insert_if_present;
 
 pub(super) fn build(payload: Map<String, Value>) -> (String, Value) {
@@ -56,22 +57,26 @@ fn apply_openrouter_overrides(body: &mut Map<String, Value>, source_payload: &Ma
 
     // OpenRouter validates `reasoning.effort` against a fixed enum
     // (xhigh|high|medium|low|minimal|none) and rejects SillyTavern's `max`/`auto`
-    // preset values. Normalize through the shared helper like the other builders
-    // (max -> high, min -> minimal, auto -> omitted, xhigh per model) instead of
-    // forwarding the raw value. Remove the flat field unconditionally so the raw
+    // preset values, so the raw value can't be forwarded. Normalize the universal
+    // aliases (auto -> omitted, max -> high, min -> minimal). The OpenAI `xhigh`
+    // gating is GPT-version specific, so it must not be applied to non-OpenAI
+    // routes: OpenRouter Claude accepts `xhigh`, so keep it instead of silently
+    // downgrading to `high`. Remove the flat field unconditionally so the raw
     // value never leaks alongside the nested `reasoning` object.
     body.remove("reasoning_effort");
+    let model = source_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("");
     if let Some(reasoning_effort) = source_payload
         .get("reasoning_effort")
         .and_then(Value::as_str)
         .and_then(|value| {
-            normalize_openai_reasoning_effort(
-                value,
-                source_payload
-                    .get("model")
-                    .and_then(Value::as_str)
-                    .unwrap_or(""),
-            )
+            if is_openrouter_claude_model_name(model) {
+                normalize_reasoning_effort(value, true)
+            } else {
+                normalize_openai_reasoning_effort(value, model)
+            }
         })
     {
         body.insert(
@@ -207,6 +212,67 @@ mod tests {
                 .as_object()
                 .and_then(|body| body.get("reasoning_effort"))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn openrouter_claude_keeps_xhigh_reasoning_effort() {
+        // OpenRouter accepts `xhigh` for Claude; the OpenAI GPT-version gating must
+        // not downgrade it to `high` on the Anthropic route.
+        let payload = json!({
+            "chat_completion_source": "openrouter",
+            "model": "anthropic/claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "xhigh"
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload);
+        assert_eq!(
+            upstream.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("xhigh")
+        );
+    }
+
+    #[test]
+    fn openrouter_claude_still_normalizes_max_reasoning_effort() {
+        // `max` is never valid in OpenRouter's enum, even for Claude.
+        let payload = json!({
+            "chat_completion_source": "openrouter",
+            "model": "anthropic/claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "max"
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload);
+        assert_eq!(
+            upstream.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn openrouter_non_claude_downgrades_xhigh_for_unsupported_model() {
+        // A non-Claude model that does not support xhigh must still be downgraded.
+        let payload = json!({
+            "chat_completion_source": "openrouter",
+            "model": "openai/gpt-5.1",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "xhigh"
+        })
+        .as_object()
+        .cloned()
+        .expect("payload must be object");
+
+        let (_, upstream) = build(payload);
+        assert_eq!(
+            upstream.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("high")
         );
     }
 

--- a/src-tauri/src/application/services/chat_completion_service/prompt_caching_plan.rs
+++ b/src-tauri/src/application/services/chat_completion_service/prompt_caching_plan.rs
@@ -104,13 +104,16 @@ fn resolve_custom_claude_prompt_caching_plan(
     }))
 }
 
+pub(super) fn is_openrouter_claude_model_name(model: &str) -> bool {
+    model.trim().to_ascii_lowercase().starts_with("anthropic/claude")
+}
+
 fn is_openrouter_claude_model(payload: &Value) -> bool {
     payload
         .as_object()
         .and_then(|object| object.get("model"))
         .and_then(Value::as_str)
-        .map(str::trim)
-        .is_some_and(|model| model.to_ascii_lowercase().starts_with("anthropic/claude"))
+        .is_some_and(is_openrouter_claude_model_name)
 }
 
 fn is_nanogpt_claude_payload(payload: &Value) -> bool {


### PR DESCRIPTION
## 问题

通过 OpenRouter 连接、reasoning effort 选 `max`（或 `auto`）时报：

> Validation error: reasoning.effort: Invalid option: expected one of "xhigh"|"high"|"medium"|"low"|"minimal"|"none"

该错误在 v2.1.0 与最新 dev/main 上均存在。

## 根因

OpenRouter 用 zod 把 `reasoning.effort` 校验为固定枚举 `{xhigh, high, medium, low, minimal, none}`，不接受 SillyTavern 预设里的 `max` / `auto`。而 `payload/openrouter.rs` 在构建请求时把 `reasoning_effort` **原样**写进 `reasoning.effort`，唯独这条路漏了归一化（`openai.rs` / `openai_responses.rs` / `nanogpt.rs` 都做了）。

## 修复

1. 把 effort 映射核心抽成 `normalize_reasoning_effort(value, allow_xhigh)`：`auto`→省略、`min`→`minimal`、`max`/`maximum`→`high`、`xhigh`→受 `allow_xhigh` 控制，其余合法值原样透传。原 `normalize_openai_reasoning_effort` 复用它（`allow_xhigh = GPT 版本门控`）。
2. OpenRouter builder 按模型分流：
   - **Claude（`anthropic/claude*`）**：`allow_xhigh = true`，保留 `xhigh`（OpenRouter 对 Claude 接受 xhigh），避免被 OpenAI 的 GPT 版本门控误降级为 `high`；但 `auto`/`max` 等通用非法值仍归一化。复用 `prompt_caching_plan::is_openrouter_claude_model_name`，不另造判定。
   - **其余模型**：走 `normalize_openai_reasoning_effort`（保留 GPT 版本 xhigh 门控）。
3. 归一化前**无条件移除**扁平 `reasoning_effort`，确保原值不与嵌套 `reasoning` 一起泄漏。

## 改动符合的约定

- **不重复造轮子**：复用既有的 `normalize_openai_reasoning_effort` 与 `is_openrouter_claude_model_name`（后者由原 `is_openrouter_claude_model` 提取）。
- **最小改动**：3 文件，集中在 effort 归一化与 OpenRouter 分流。
- **测试就近**：新增 `openrouter_normalizes_max_reasoning_effort_to_high`、`openrouter_omits_auto_reasoning_effort`、`openrouter_claude_keeps_xhigh_reasoning_effort`、`openrouter_claude_still_normalizes_max_reasoning_effort`、`openrouter_non_claude_downgrades_xhigh_for_unsupported_model`。

## Test plan

- [ ] `cd src-tauri && cargo test --lib openrouter`
- [ ] `cd src-tauri && cargo test --lib openai_reasoning`
- [ ] 实机：OpenRouter + Claude，effort 选 `xhigh` 应保留；effort 选 `max` 应变 `high`，均不再报 `reasoning.effort: Invalid option`