### PR TITLE
fix: prevent data loss when saving with stale cursor from mode switch

### DIFF
--- a/src-tauri/src/application/dto/chat_dto.rs
+++ b/src-tauri/src/application/dto/chat_dto.rs
@@ -172,6 +172,7 @@ pub struct SaveChatWindowedDto {
     pub cursor: ChatPayloadCursor,
     pub header: String,
     pub lines: Vec<String>,
+    pub expected_window_line_count: usize,
     pub force: Option<bool>,
 }
 
@@ -184,6 +185,7 @@ pub struct PatchChatWindowedDto {
     pub cursor: ChatPayloadCursor,
     pub header: String,
     pub patch: ChatPayloadPatchOp,
+    pub expected_window_line_count: usize,
     pub force: Option<bool>,
 }
 
@@ -202,6 +204,7 @@ pub struct SaveGroupChatWindowedDto {
     pub cursor: ChatPayloadCursor,
     pub header: String,
     pub lines: Vec<String>,
+    pub expected_window_line_count: usize,
     pub force: Option<bool>,
 }
 
@@ -212,6 +215,7 @@ pub struct PatchGroupChatWindowedDto {
     pub cursor: ChatPayloadCursor,
     pub header: String,
     pub patch: ChatPayloadPatchOp,
+    pub expected_window_line_count: usize,
     pub force: Option<bool>,
 }
 

--- a/src-tauri/src/application/services/chat_service.rs
+++ b/src-tauri/src/application/services/chat_service.rs
@@ -627,13 +627,22 @@ impl ChatService {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, ApplicationError> {
         validate_character_path_component(character_name)?;
         validate_chat_file_name(file_name, "Chat file name")?;
 
         self.chat_repository
-            .save_chat_payload_windowed(character_name, file_name, cursor, header, lines, force)
+            .save_chat_payload_windowed(
+                character_name,
+                file_name,
+                cursor,
+                header,
+                lines,
+                expected_window_line_count,
+                force,
+            )
             .await
             .map_err(Into::into)
     }
@@ -646,13 +655,22 @@ impl ChatService {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, ApplicationError> {
         validate_character_path_component(character_name)?;
         validate_chat_file_name(file_name, "Chat file name")?;
 
         self.chat_repository
-            .patch_chat_payload_windowed(character_name, file_name, cursor, header, op, force)
+            .patch_chat_payload_windowed(
+                character_name,
+                file_name,
+                cursor,
+                header,
+                op,
+                expected_window_line_count,
+                force,
+            )
             .await
             .map_err(Into::into)
     }

--- a/src-tauri/src/application/services/group_chat_service.rs
+++ b/src-tauri/src/application/services/group_chat_service.rs
@@ -299,12 +299,20 @@ impl GroupChatService {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, ApplicationError> {
         validate_chat_file_name(chat_id, "Group chat id")?;
 
         self.group_chat_repository
-            .save_group_chat_payload_windowed(chat_id, cursor, header, lines, force)
+            .save_group_chat_payload_windowed(
+                chat_id,
+                cursor,
+                header,
+                lines,
+                expected_window_line_count,
+                force,
+            )
             .await
             .map_err(Into::into)
     }
@@ -316,12 +324,20 @@ impl GroupChatService {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, ApplicationError> {
         validate_chat_file_name(chat_id, "Group chat id")?;
 
         self.group_chat_repository
-            .patch_group_chat_payload_windowed(chat_id, cursor, header, op, force)
+            .patch_group_chat_payload_windowed(
+                chat_id,
+                cursor,
+                header,
+                op,
+                expected_window_line_count,
+                force,
+            )
             .await
             .map_err(Into::into)
     }

--- a/src-tauri/src/domain/repositories/chat_repository.rs
+++ b/src-tauri/src/domain/repositories/chat_repository.rs
@@ -169,10 +169,13 @@ pub trait ChatRepository: Send + Sync {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError>;
 
     /// Patch a windowed character chat payload by applying an operation at the tail.
+    /// `expected_window_line_count` is the window baseline contract: how many message
+    /// lines the caller's last successful load/save left between cursor.offset and EOF.
     async fn patch_chat_payload_windowed(
         &self,
         character_name: &str,
@@ -180,6 +183,7 @@ pub trait ChatRepository: Send + Sync {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError>;
 

--- a/src-tauri/src/domain/repositories/group_chat_repository.rs
+++ b/src-tauri/src/domain/repositories/group_chat_repository.rs
@@ -62,16 +62,20 @@ pub trait GroupChatRepository: Send + Sync {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError>;
 
     /// Patch a windowed group chat payload by applying an operation at the tail.
+    /// `expected_window_line_count` is the window baseline contract: how many message
+    /// lines the caller's last successful load/save left between cursor.offset and EOF.
     async fn patch_group_chat_payload_windowed(
         &self,
         chat_id: &str,
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError>;
 

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/group_chat_repository_impl.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/group_chat_repository_impl.rs
@@ -161,10 +161,18 @@ impl GroupChatRepository for FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
-        self.save_group_payload_windowed(chat_id, cursor, header, lines, force)
-            .await
+        self.save_group_payload_windowed(
+            chat_id,
+            cursor,
+            header,
+            lines,
+            expected_window_line_count,
+            force,
+        )
+        .await
     }
 
     async fn patch_group_chat_payload_windowed(
@@ -173,10 +181,18 @@ impl GroupChatRepository for FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
-        self.patch_group_payload_windowed(chat_id, cursor, header, op, force)
-            .await
+        self.patch_group_payload_windowed(
+            chat_id,
+            cursor,
+            header,
+            op,
+            expected_window_line_count,
+            force,
+        )
+        .await
     }
 
     async fn save_group_chat_payload_from_path(

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/repository_impl.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/repository_impl.rs
@@ -591,6 +591,7 @@ impl ChatRepository for FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
         self.save_character_payload_windowed(
@@ -599,6 +600,7 @@ impl ChatRepository for FileChatRepository {
             cursor,
             header,
             lines,
+            expected_window_line_count,
             force,
         )
         .await
@@ -611,10 +613,19 @@ impl ChatRepository for FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
-        self.patch_character_payload_windowed(character_name, file_name, cursor, header, op, force)
-            .await
+        self.patch_character_payload_windowed(
+            character_name,
+            file_name,
+            cursor,
+            header,
+            op,
+            expected_window_line_count,
+            force,
+        )
+        .await
     }
 
     async fn save_chat_payload_from_path(

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/tests.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/tests.rs
@@ -2408,6 +2408,7 @@ async fn patch_chat_payload_windowed_appends_and_rewrites_tail() {
             ChatPayloadPatchOp::Append {
                 lines: vec![new_line.clone()],
             },
+            2,
             false,
         )
         .await
@@ -2444,6 +2445,7 @@ async fn patch_chat_payload_windowed_appends_and_rewrites_tail() {
                 start_index: 2,
                 lines: vec![updated_line],
             },
+            3,
             false,
         )
         .await
@@ -2471,6 +2473,7 @@ async fn patch_chat_payload_windowed_appends_and_rewrites_tail() {
                 start_index: 1,
                 lines: Vec::new(),
             },
+            3,
             false,
         )
         .await
@@ -2523,11 +2526,143 @@ async fn patch_chat_payload_windowed_rejects_missing_integrity_when_existing_has
             tail.cursor,
             missing_integrity_header,
             ChatPayloadPatchOp::Append { lines: Vec::new() },
+            tail.lines.len(),
             false,
         )
         .await
         .expect_err("patch should fail when incoming integrity is missing");
     assert!(matches!(error, DomainError::InvalidData(message) if message == "integrity"));
+
+    let _ = fs::remove_dir_all(&root).await;
+}
+
+#[tokio::test]
+async fn patch_chat_payload_windowed_rejects_window_baseline_mismatch() {
+    let (repository, root) = setup_repository().await;
+
+    let character_name = "alice";
+    let file_name = "session";
+
+    let mut payload = vec![payload_with_integrity("baseline-a")[0].clone()];
+    for index in 0..5 {
+        payload.push(json!({
+            "name": "User",
+            "is_user": true,
+            "send_date": format!("2026-01-01T00:00:0{}.000Z", index),
+            "mes": format!("message {}", index),
+            "extra": {},
+        }));
+    }
+
+    save_chat_payload_from_values(
+        &repository,
+        &root,
+        character_name,
+        file_name,
+        &payload,
+        false,
+    )
+    .await
+    .expect("save initial payload");
+
+    let windowed_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, 2)
+        .await
+        .expect("get windowed tail");
+    assert_eq!(windowed_tail.lines.len(), 2);
+
+    let full_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, 100)
+        .await
+        .expect("get full tail");
+    assert_eq!(full_tail.lines.len(), 5);
+
+    let new_line = serde_json::to_string(&json!({
+        "name": "User",
+        "is_user": true,
+        "send_date": "2026-01-01T00:00:09.000Z",
+        "mes": "appended",
+        "extra": {},
+    }))
+    .expect("serialize new line");
+
+    // Append with a stale full-mode offset but a valid file signature: before the
+    // baseline contract this passed silently and returned the bad offset re-signed
+    // with the new file signature.
+    let error = repository
+        .patch_chat_payload_windowed(
+            character_name,
+            file_name,
+            full_tail.cursor,
+            windowed_tail.header.clone(),
+            ChatPayloadPatchOp::Append {
+                lines: vec![new_line.clone()],
+            },
+            windowed_tail.lines.len(),
+            false,
+        )
+        .await
+        .expect_err("append with stale offset must be rejected");
+    assert!(
+        format!("{}", error).contains("Window baseline mismatch"),
+        "error should mention the window baseline, got: {}",
+        error
+    );
+
+    // RewriteFromIndex with a wrong declared baseline is rejected too.
+    let error = repository
+        .patch_chat_payload_windowed(
+            character_name,
+            file_name,
+            windowed_tail.cursor,
+            windowed_tail.header.clone(),
+            ChatPayloadPatchOp::RewriteFromIndex {
+                start_index: 0,
+                lines: vec![new_line.clone()],
+            },
+            4,
+            false,
+        )
+        .await
+        .expect_err("rewrite with wrong baseline must be rejected");
+    assert!(
+        format!("{}", error).contains("Window baseline mismatch"),
+        "error should mention the window baseline, got: {}",
+        error
+    );
+
+    // File untouched by the rejected writes.
+    let bytes = repository
+        .get_chat_payload_bytes(character_name, file_name)
+        .await
+        .expect("read payload bytes");
+    assert_eq!(
+        String::from_utf8(bytes).expect("utf8").lines().count(),
+        6,
+        "rejected writes must not modify the file"
+    );
+
+    // The same append with the correct baseline succeeds.
+    repository
+        .patch_chat_payload_windowed(
+            character_name,
+            file_name,
+            windowed_tail.cursor,
+            windowed_tail.header,
+            ChatPayloadPatchOp::Append {
+                lines: vec![new_line],
+            },
+            windowed_tail.lines.len(),
+            false,
+        )
+        .await
+        .expect("append with correct baseline");
+
+    let bytes = repository
+        .get_chat_payload_bytes(character_name, file_name)
+        .await
+        .expect("read payload bytes after append");
+    assert_eq!(String::from_utf8(bytes).expect("utf8").lines().count(), 7);
 
     let _ = fs::remove_dir_all(&root).await;
 }
@@ -2555,4 +2690,242 @@ fn payload_to_jsonl(payload: &[Value]) -> String {
         .map(|item| serde_json::to_string(item).expect("serialize line"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// ============================================================================
+// Data loss reproduction: mode switch (full ↔ windowed) with stale cursor
+// ============================================================================
+
+fn generate_large_payload(num_messages: usize, integrity: &str) -> Vec<Value> {
+    let mut payload = vec![json!({
+        "chat_metadata": {
+            "integrity": integrity,
+        },
+        "user_name": "User",
+        "character_name": "Character",
+    })];
+
+    for i in 0..num_messages {
+        let is_user = i % 2 == 0;
+        let large_content = format!("Message {} content. {}", i, "X".repeat(2000));
+        payload.push(json!({
+            "name": if is_user { "User" } else { "Character" },
+            "is_user": is_user,
+            "send_date": format!("2026-06-{:02}T{:02}:{:02}:00.000Z",
+                1 + (i / 48).min(29),
+                (i % 48) / 2,
+                if i % 2 == 0 { 0 } else { 30 }
+            ),
+            "mes": large_content,
+            "extra": {},
+        }));
+    }
+
+    payload
+}
+
+/// TEST 1: Full → Windowed mode switch.
+/// Full-mode cursor (offset=header_end) used with only 50 windowed messages.
+/// Expected: 250 messages silently destroyed.
+#[tokio::test]
+async fn repro_full_to_windowed_mode_switch_data_loss() {
+    let (repository, root) = setup_repository().await;
+
+    let character_name = "test-char";
+    let file_name = "session";
+    let num_messages: usize = 300;
+    let window_size: usize = 50;
+
+    let payload = generate_large_payload(num_messages, "repro-test");
+    save_chat_payload_from_values(
+        &repository,
+        &root,
+        character_name,
+        file_name,
+        &payload,
+        false,
+    )
+    .await
+    .expect("save 300-message payload");
+
+    // Load full mode
+    let full_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, 10000)
+        .await
+        .expect("get full tail");
+    let cursor_full = full_tail.cursor;
+    assert_eq!(full_tail.lines.len(), num_messages);
+    assert!(!full_tail.has_more_before);
+
+    // Load windowed mode (without modifying file)
+    let windowed_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, window_size)
+        .await
+        .expect("get windowed tail");
+    assert_eq!(windowed_tail.lines.len(), window_size);
+    assert!(windowed_tail.has_more_before);
+
+    // Verify: same signature, different offsets
+    assert_eq!(cursor_full.size, windowed_tail.cursor.size);
+    assert_eq!(
+        cursor_full.modified_millis,
+        windowed_tail.cursor.modified_millis
+    );
+    assert!(
+        cursor_full.offset < windowed_tail.cursor.offset,
+        "full offset ({}) < windowed offset ({})",
+        cursor_full.offset,
+        windowed_tail.cursor.offset
+    );
+
+    println!("=== Full → Windowed ===");
+    println!("Full cursor offset:     {}", cursor_full.offset);
+    println!("Windowed cursor offset: {}", windowed_tail.cursor.offset);
+    println!(
+        "Data at risk: {} bytes",
+        windowed_tail.cursor.offset - cursor_full.offset
+    );
+
+    // THE BUG: save with full cursor + only windowed messages
+    let save_result = repository
+        .save_chat_payload_windowed(
+            character_name,
+            file_name,
+            cursor_full,
+            full_tail.header,
+            windowed_tail.lines,
+            window_size,
+            false,
+        )
+        .await;
+
+    // Verify: save must be rejected to prevent data loss
+    assert!(
+        save_result.is_err(),
+        "Save with mismatched cursor/lines should be rejected"
+    );
+    let err_msg = format!("{}", save_result.unwrap_err());
+    assert!(
+        err_msg.contains("Window baseline mismatch"),
+        "Error should mention the window baseline, got: {}",
+        err_msg
+    );
+
+    // Verify file is intact
+    let bytes = repository
+        .get_chat_payload_bytes(character_name, file_name)
+        .await
+        .expect("read post-rejected-save");
+    let post_line_count = String::from_utf8(bytes).expect("utf8").lines().count();
+    assert_eq!(
+        post_line_count,
+        num_messages + 1,
+        "File should be untouched after rejected save"
+    );
+
+    println!(
+        "PASS: Full→Windowed stale cursor rejected, all {} messages safe.",
+        num_messages
+    );
+
+    let _ = fs::remove_dir_all(&root).await;
+}
+
+/// TEST 2: Windowed → Full mode switch (user's actual scenario).
+/// Windowed-mode cursor (offset near file end) used with all 300 messages from full reload.
+/// The full-mode save writes all messages but truncates from the windowed offset,
+/// potentially duplicating or misplacing messages.
+#[tokio::test]
+async fn repro_windowed_to_full_mode_switch_data_loss() {
+    let (repository, root) = setup_repository().await;
+
+    let character_name = "test-char-w2f";
+    let file_name = "session";
+    let num_messages: usize = 300;
+    let window_size: usize = 50;
+
+    let payload = generate_large_payload(num_messages, "w2f-test");
+    save_chat_payload_from_values(
+        &repository,
+        &root,
+        character_name,
+        file_name,
+        &payload,
+        false,
+    )
+    .await
+    .expect("save 300-message payload");
+
+    // Step 1: User is in windowed mode
+    let windowed_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, window_size)
+        .await
+        .expect("get windowed tail");
+    let cursor_windowed = windowed_tail.cursor;
+    assert_eq!(windowed_tail.lines.len(), window_size);
+    assert!(windowed_tail.has_more_before);
+
+    // Step 2: User switches to full mode — frontend reloads all messages
+    let full_tail = repository
+        .get_chat_payload_tail_lines(character_name, file_name, 10000)
+        .await
+        .expect("get full tail");
+    assert_eq!(full_tail.lines.len(), num_messages);
+
+    println!("=== Windowed → Full ===");
+    println!(
+        "Windowed cursor offset: {} (near end of file)",
+        cursor_windowed.offset
+    );
+    println!(
+        "Full cursor offset:     {} (near header end)",
+        full_tail.cursor.offset
+    );
+    println!("File size: {}", cursor_windowed.size);
+
+    // THE BUG: save with windowed cursor + ALL 300 messages from full reload.
+    // set_len(cursor_windowed.offset) keeps prefix up to windowed offset,
+    // then writes ALL 300 messages after it.
+    // Result: messages 1-250 exist TWICE (once in preserved prefix, once in written payload)
+    // or the file becomes corrupted/oversized.
+    let save_result = repository
+        .save_chat_payload_windowed(
+            character_name,
+            file_name,
+            cursor_windowed, // STALE: offset near file end
+            full_tail.header,
+            full_tail.lines, // ALL 300 messages
+            num_messages,
+            false,
+        )
+        .await;
+
+    assert!(
+        save_result.is_err(),
+        "Save with mismatched cursor/lines should be rejected"
+    );
+    let err_msg = format!("{}", save_result.unwrap_err());
+    assert!(
+        err_msg.contains("Window baseline mismatch"),
+        "Error should mention the window baseline, got: {}",
+        err_msg
+    );
+
+    let bytes = repository
+        .get_chat_payload_bytes(character_name, file_name)
+        .await
+        .expect("read post-rejected-save");
+    let post_line_count = String::from_utf8(bytes).expect("utf8").lines().count();
+    assert_eq!(
+        post_line_count,
+        num_messages + 1,
+        "File should be untouched after rejected save"
+    );
+
+    println!(
+        "PASS: Windowed->Full stale cursor rejected, all {} messages safe.",
+        num_messages
+    );
+
+    let _ = fs::remove_dir_all(&root).await;
 }

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_patch.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_patch.rs
@@ -14,8 +14,8 @@ use super::windowed_payload_io::{
     WINDOW_READ_CHUNK_BYTES, cursor_from_metadata, ensure_parent_dir,
     extract_integrity_slug_from_header_line, map_open_existing_error, open_existing_payload_file,
     read_existing_payload_metadata, read_first_line_and_end_offset, replace_file,
-    verify_cursor_offset_is_line_boundary, verify_cursor_signature,
-    verify_window_line_consistency, write_jsonl_lines_at_end, write_jsonl_lines_to_file,
+    verify_cursor_offset_is_line_boundary, verify_cursor_signature, verify_window_baseline,
+    write_jsonl_lines_at_end, write_jsonl_lines_to_file,
 };
 
 impl FileChatRepository {
@@ -26,6 +26,7 @@ impl FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
         self.ensure_directory_exists().await?;
@@ -42,7 +43,15 @@ impl FileChatRepository {
         })?;
 
         let _write_guard = self.acquire_payload_write_lock(&path).await;
-        let result = patch_payload_windowed_internal(&path, cursor, header, op, force).await?;
+        let result = patch_payload_windowed_internal(
+            &path,
+            cursor,
+            header,
+            op,
+            expected_window_line_count,
+            force,
+        )
+        .await?;
 
         {
             let mut cache = self.memory_cache.lock().await;
@@ -62,6 +71,7 @@ impl FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         op: ChatPayloadPatchOp,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
         self.ensure_directory_exists().await?;
@@ -69,7 +79,15 @@ impl FileChatRepository {
         let path = self.get_group_chat_path(chat_id)?;
         let _write_guard = self.acquire_payload_write_lock(&path).await;
         let backup_key = Self::get_group_backup_key(chat_id)?;
-        let result = patch_payload_windowed_internal(&path, cursor, header, op, force).await?;
+        let result = patch_payload_windowed_internal(
+            &path,
+            cursor,
+            header,
+            op,
+            expected_window_line_count,
+            force,
+        )
+        .await?;
 
         self.remove_summary_cache_for_path(&path).await;
         self.backup_chat_file(&path, chat_id, &backup_key).await?;
@@ -162,6 +180,7 @@ async fn patch_payload_windowed_internal(
     cursor: ChatPayloadCursor,
     header: String,
     op: ChatPayloadPatchOp,
+    expected_window_line_count: usize,
     force: bool,
 ) -> Result<ChatPayloadCursor, DomainError> {
     let header_integrity = extract_integrity_slug_from_header_line(&header)?;
@@ -238,6 +257,21 @@ async fn patch_payload_windowed_internal(
         (Ok(a), Ok(b)) => a != b,
         _ => existing_header != header,
     };
+
+    // Window baseline contract: both ops anchor on cursor.offset, so a stale
+    // offset must be rejected before any bytes are written — Append included,
+    // otherwise the bad offset gets re-signed into the returned cursor.
+    let header_only = existing_header_end_offset == metadata.len();
+    if !(header_only && cursor.offset == existing_header_end_offset) {
+        verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
+    }
+    verify_window_baseline(
+        path,
+        cursor.offset,
+        metadata.len(),
+        expected_window_line_count,
+    )
+    .await?;
 
     match op {
         ChatPayloadPatchOp::Append { lines } => {
@@ -348,8 +382,6 @@ async fn patch_payload_windowed_internal(
             }
         }
         ChatPayloadPatchOp::RewriteFromIndex { start_index, lines } => {
-            verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
-
             let start_offset =
                 find_line_start_offset_from_cursor(path, cursor.offset, start_index).await?;
 
@@ -361,10 +393,6 @@ async fn patch_payload_windowed_internal(
             }
 
             let has_lines = lines.iter().any(|line| !line.trim().is_empty());
-
-            let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
-            verify_window_line_consistency(path, start_offset, metadata.len(), writing_count)
-                .await?;
 
             if !header_changed {
                 let mut file = OpenOptions::new()

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_patch.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_patch.rs
@@ -14,8 +14,8 @@ use super::windowed_payload_io::{
     WINDOW_READ_CHUNK_BYTES, cursor_from_metadata, ensure_parent_dir,
     extract_integrity_slug_from_header_line, map_open_existing_error, open_existing_payload_file,
     read_existing_payload_metadata, read_first_line_and_end_offset, replace_file,
-    verify_cursor_offset_is_line_boundary, verify_cursor_signature, write_jsonl_lines_at_end,
-    write_jsonl_lines_to_file,
+    verify_cursor_offset_is_line_boundary, verify_cursor_signature,
+    verify_window_line_consistency, write_jsonl_lines_at_end, write_jsonl_lines_to_file,
 };
 
 impl FileChatRepository {
@@ -361,6 +361,10 @@ async fn patch_payload_windowed_internal(
             }
 
             let has_lines = lines.iter().any(|line| !line.trim().is_empty());
+
+            let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
+            verify_window_line_consistency(path, start_offset, metadata.len(), writing_count)
+                .await?;
 
             if !header_changed {
                 let mut file = OpenOptions::new()

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload.rs
@@ -165,6 +165,7 @@ impl FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
         self.ensure_directory_exists().await?;
@@ -181,7 +182,15 @@ impl FileChatRepository {
         })?;
 
         let _write_guard = self.acquire_payload_write_lock(&path).await;
-        let result = save_payload_windowed_internal(&path, cursor, header, lines, force).await?;
+        let result = save_payload_windowed_internal(
+            &path,
+            cursor,
+            header,
+            lines,
+            expected_window_line_count,
+            force,
+        )
+        .await?;
 
         {
             let mut cache = self.memory_cache.lock().await;
@@ -220,6 +229,7 @@ impl FileChatRepository {
         cursor: ChatPayloadCursor,
         header: String,
         lines: Vec<String>,
+        expected_window_line_count: usize,
         force: bool,
     ) -> Result<ChatPayloadCursor, DomainError> {
         self.ensure_directory_exists().await?;
@@ -227,7 +237,15 @@ impl FileChatRepository {
         let path = self.get_group_chat_path(chat_id)?;
         let _write_guard = self.acquire_payload_write_lock(&path).await;
         let backup_key = Self::get_group_backup_key(chat_id)?;
-        let result = save_payload_windowed_internal(&path, cursor, header, lines, force).await?;
+        let result = save_payload_windowed_internal(
+            &path,
+            cursor,
+            header,
+            lines,
+            expected_window_line_count,
+            force,
+        )
+        .await?;
 
         self.remove_summary_cache_for_path(&path).await;
         self.backup_chat_file(&path, chat_id, &backup_key).await?;
@@ -312,6 +330,7 @@ async fn save_payload_windowed_internal(
     cursor: ChatPayloadCursor,
     header: String,
     lines: Vec<String>,
+    expected_window_line_count: usize,
     force: bool,
 ) -> Result<ChatPayloadCursor, DomainError> {
     let header_integrity = extract_integrity_slug_from_header_line(&header)?;
@@ -379,14 +398,19 @@ async fn save_payload_windowed_internal(
         _ => existing_header != header,
     };
 
+    // Window baseline contract: reject stale cursors before truncating.
+    if !(header_only && cursor.offset == existing_header_end_offset) {
+        verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
+    }
+    verify_window_baseline(
+        path,
+        cursor.offset,
+        metadata.len(),
+        expected_window_line_count,
+    )
+    .await?;
+
     if !header_changed {
-        if !(header_only && cursor.offset == existing_header_end_offset) {
-            verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
-        }
-
-        let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
-        verify_window_line_consistency(path, cursor.offset, metadata.len(), writing_count).await?;
-
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -451,13 +475,6 @@ async fn save_payload_windowed_internal(
             DomainError::InternalError(format!("Failed to flush chat payload file: {}", error))
         })?;
     } else {
-        if !(header_only && cursor.offset == existing_header_end_offset) {
-            verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
-        }
-
-        let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
-        verify_window_line_consistency(path, cursor.offset, metadata.len(), writing_count).await?;
-
         ensure_parent_dir(path).await?;
 
         let temp_path = FileChatRepository::temp_payload_path(path);

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload.rs
@@ -384,6 +384,9 @@ async fn save_payload_windowed_internal(
             verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
         }
 
+        let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
+        verify_window_line_consistency(path, cursor.offset, metadata.len(), writing_count).await?;
+
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -451,6 +454,10 @@ async fn save_payload_windowed_internal(
         if !(header_only && cursor.offset == existing_header_end_offset) {
             verify_cursor_offset_is_line_boundary(path, cursor.offset).await?;
         }
+
+        let writing_count = lines.iter().filter(|l| !l.trim().is_empty()).count();
+        verify_window_line_consistency(path, cursor.offset, metadata.len(), writing_count).await?;
+
         ensure_parent_dir(path).await?;
 
         let temp_path = FileChatRepository::temp_payload_path(path);

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload_io.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload_io.rs
@@ -269,6 +269,110 @@ pub(super) fn verify_cursor_signature(
     Ok(())
 }
 
+/// Count the number of JSONL lines between `start_offset` and `end_offset`.
+pub(super) async fn count_lines_in_region(
+    path: &Path,
+    start_offset: u64,
+    end_offset: u64,
+) -> Result<usize, DomainError> {
+    if end_offset <= start_offset {
+        return Ok(0);
+    }
+
+    let mut file = open_existing_payload_file(path).await?;
+    file.seek(SeekFrom::Start(start_offset))
+        .await
+        .map_err(|error| {
+            DomainError::InternalError(format!(
+                "Failed to seek chat payload file {:?}: {}",
+                path, error
+            ))
+        })?;
+
+    let region_len = (end_offset - start_offset) as usize;
+    let mut remaining = region_len;
+    let mut line_count: usize = 0;
+    let mut buf = vec![0u8; WINDOW_READ_CHUNK_BYTES.min(region_len)];
+
+    while remaining > 0 {
+        let to_read = buf.len().min(remaining);
+        let n = file.read(&mut buf[..to_read]).await.map_err(|error| {
+            DomainError::InternalError(format!(
+                "Failed to read chat payload file {:?}: {}",
+                path, error
+            ))
+        })?;
+        if n == 0 {
+            break;
+        }
+        line_count += buf[..n].iter().filter(|&&b| b == b'\n').count();
+        remaining -= n;
+    }
+
+    // The last line may not end with \n, count it if there's content
+    if region_len > 0 {
+        line_count += 1;
+        // But if the region ends with \n, we already counted it
+        if remaining == 0 {
+            let mut last_byte = [0u8; 1];
+            file.seek(SeekFrom::Start(end_offset - 1))
+                .await
+                .map_err(|error| {
+                    DomainError::InternalError(format!(
+                        "Failed to seek chat payload file {:?}: {}",
+                        path, error
+                    ))
+                })?;
+            let n = file.read(&mut last_byte).await.map_err(|error| {
+                DomainError::InternalError(format!(
+                    "Failed to read chat payload file {:?}: {}",
+                    path, error
+                ))
+            })?;
+            if n == 1 && last_byte[0] == b'\n' {
+                line_count -= 1;
+            }
+        }
+    }
+
+    Ok(line_count)
+}
+
+/// Verify that the number of lines being written is consistent with the window
+/// region on disk. Prevents silent data loss from mode-switch stale cursors
+/// where cursor.offset doesn't match the actual window loaded by the frontend.
+pub(super) async fn verify_window_line_consistency(
+    path: &Path,
+    cursor_offset: u64,
+    file_size: u64,
+    writing_line_count: usize,
+) -> Result<(), DomainError> {
+    let window_lines_on_disk = count_lines_in_region(path, cursor_offset, file_size).await?;
+
+    if window_lines_on_disk == 0 || writing_line_count == 0 {
+        return Ok(());
+    }
+
+    // Allow reasonable edits: written count can differ by up to max(20, 50% of window)
+    let tolerance = (window_lines_on_disk / 2).max(20);
+    let diff = if writing_line_count > window_lines_on_disk {
+        writing_line_count - window_lines_on_disk
+    } else {
+        window_lines_on_disk - writing_line_count
+    };
+
+    if diff > tolerance {
+        return Err(DomainError::InvalidData(format!(
+            "Window line count mismatch for {:?}: cursor window has {} lines on disk \
+             but {} lines are being written (diff={}). This may indicate a stale cursor \
+             from a mode switch (full/windowed). Reload the chat and retry.",
+            path, window_lines_on_disk, writing_line_count, diff
+        )));
+    }
+
+    Ok(())
+}
+
 pub(super) async fn verify_cursor_offset_is_line_boundary(
     path: &Path,
     cursor_offset: u64,

--- a/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload_io.rs
+++ b/src-tauri/src/infrastructure/repositories/file_chat_repository/windowed_payload_io.rs
@@ -338,35 +338,25 @@ pub(super) async fn count_lines_in_region(
     Ok(line_count)
 }
 
-/// Verify that the number of lines being written is consistent with the window
-/// region on disk. Prevents silent data loss from mode-switch stale cursors
-/// where cursor.offset doesn't match the actual window loaded by the frontend.
-pub(super) async fn verify_window_line_consistency(
+/// Verify the window baseline contract: the caller declares how many message
+/// lines its last successful load/save left between cursor.offset and EOF,
+/// and the write is rejected unless the file still matches exactly. Catches
+/// stale cursors (mode switch, concurrent writer) without the false
+/// accepts/rejects of a tolerance heuristic.
+pub(super) async fn verify_window_baseline(
     path: &Path,
     cursor_offset: u64,
     file_size: u64,
-    writing_line_count: usize,
+    expected_window_line_count: usize,
 ) -> Result<(), DomainError> {
     let window_lines_on_disk = count_lines_in_region(path, cursor_offset, file_size).await?;
 
-    if window_lines_on_disk == 0 || writing_line_count == 0 {
-        return Ok(());
-    }
-
-    // Allow reasonable edits: written count can differ by up to max(20, 50% of window)
-    let tolerance = (window_lines_on_disk / 2).max(20);
-    let diff = if writing_line_count > window_lines_on_disk {
-        writing_line_count - window_lines_on_disk
-    } else {
-        window_lines_on_disk - writing_line_count
-    };
-
-    if diff > tolerance {
+    if window_lines_on_disk != expected_window_line_count {
         return Err(DomainError::InvalidData(format!(
-            "Window line count mismatch for {:?}: cursor window has {} lines on disk \
-             but {} lines are being written (diff={}). This may indicate a stale cursor \
-             from a mode switch (full/windowed). Reload the chat and retry.",
-            path, window_lines_on_disk, writing_line_count, diff
+            "Window baseline mismatch for {:?}: expected {} message lines after the \
+             cursor but found {} on disk. The cursor is stale (mode switch or \
+             concurrent write). Reload the chat and retry.",
+            path, expected_window_line_count, window_lines_on_disk
         )));
     }
 

--- a/src-tauri/src/presentation/commands/chat_commands.rs
+++ b/src-tauri/src/presentation/commands/chat_commands.rs
@@ -427,6 +427,7 @@ pub async fn save_chat_payload_windowed(
             dto.cursor,
             dto.header,
             dto.lines,
+            dto.expected_window_line_count,
             dto.force.unwrap_or(false),
         )
         .await
@@ -451,6 +452,7 @@ pub async fn patch_chat_payload_windowed(
             dto.cursor,
             dto.header,
             dto.patch,
+            dto.expected_window_line_count,
             dto.force.unwrap_or(false),
         )
         .await

--- a/src-tauri/src/presentation/commands/group_chat_commands.rs
+++ b/src-tauri/src/presentation/commands/group_chat_commands.rs
@@ -179,6 +179,7 @@ pub async fn save_group_chat_payload_windowed(
             dto.cursor,
             dto.header,
             dto.lines,
+            dto.expected_window_line_count,
             dto.force.unwrap_or(false),
         )
         .await
@@ -201,6 +202,7 @@ pub async fn patch_group_chat_payload_windowed(
             dto.cursor,
             dto.header,
             dto.patch,
+            dto.expected_window_line_count,
             dto.force.unwrap_or(false),
         )
         .await

--- a/src/script.js
+++ b/src/script.js
@@ -8394,6 +8394,7 @@ async function saveChatUnsafe({ chatName, withMetadata, mesId, force = false, ch
                     patch,
                     savedMessageCount: nextSavedMessageCount,
                     dirtyFromIndex: nextDirtyFromIndex,
+                    expectedWindowLineCount,
                 } = buildWindowedPayloadPatch(trimmedChat, windowState, 'chat');
 
                 const cursor = await patchCharacterChatPayloadWindowed({
@@ -8403,6 +8404,7 @@ async function saveChatUnsafe({ chatName, withMetadata, mesId, force = false, ch
                     cursor: windowState.cursor,
                     header: JSON.stringify(chatHeader),
                     patch,
+                    expectedWindowLineCount,
                     force: Boolean(force),
                 });
 

--- a/src/scripts/group-chats.js
+++ b/src/scripts/group-chats.js
@@ -768,6 +768,7 @@ async function saveGroupChatUnsafe(groupId, shouldSaveGroup, force = false) {
 	                    patch,
 	                    savedMessageCount: nextSavedMessageCount,
 	                    dirtyFromIndex: nextDirtyFromIndex,
+	                    expectedWindowLineCount,
 	                } = buildWindowedPayloadPatch(chat, windowState, 'group chat');
 
                 const cursor = await patchGroupChatPayloadWindowed({
@@ -775,6 +776,7 @@ async function saveGroupChatUnsafe(groupId, shouldSaveGroup, force = false) {
                     cursor: windowState.cursor,
                     header: JSON.stringify(chatHeader),
 	                    patch,
+	                    expectedWindowLineCount,
 	                    force: Boolean(force),
 	                });
 

--- a/src/scripts/tauri/chat/transport.js
+++ b/src/scripts/tauri/chat/transport.js
@@ -206,7 +206,15 @@ export async function saveCharacterChatPayload({ characterName, avatarUrl, fileN
     }));
 }
 
-export async function saveCharacterChatPayloadWindowed({ characterName, avatarUrl, fileName, cursor, payload, force = false }) {
+function normalizeExpectedWindowLineCount(value) {
+    const normalized = Number(value);
+    if (!Number.isInteger(normalized) || normalized < 0) {
+        throw new Error('Windowed chat baseline expectedWindowLineCount is missing');
+    }
+    return normalized;
+}
+
+export async function saveCharacterChatPayloadWindowed({ characterName, avatarUrl, fileName, cursor, payload, expectedWindowLineCount, force = false }) {
     const normalizedCharacter = resolveCharacterDirectoryId(characterName, avatarUrl);
     const normalizedFile = normalizeChatFileName(fileName);
     if (!Array.isArray(payload) || payload.length === 0 || !normalizedCharacter || !normalizedFile.trim()) {
@@ -223,12 +231,13 @@ export async function saveCharacterChatPayloadWindowed({ characterName, avatarUr
             cursor,
             header,
             lines,
+            expected_window_line_count: normalizeExpectedWindowLineCount(expectedWindowLineCount),
             force,
         },
     });
 }
 
-export async function patchCharacterChatPayloadWindowed({ characterName, avatarUrl, fileName, cursor, header, patch, force = false }) {
+export async function patchCharacterChatPayloadWindowed({ characterName, avatarUrl, fileName, cursor, header, patch, expectedWindowLineCount, force = false }) {
     const normalizedCharacter = resolveCharacterDirectoryId(characterName, avatarUrl);
     const normalizedFile = normalizeChatFileName(fileName);
     if (!normalizedCharacter || !normalizedFile.trim()) {
@@ -242,6 +251,7 @@ export async function patchCharacterChatPayloadWindowed({ characterName, avatarU
             cursor,
             header: String(header),
             patch,
+            expected_window_line_count: normalizeExpectedWindowLineCount(expectedWindowLineCount),
             force,
         },
     });
@@ -349,7 +359,7 @@ export async function saveGroupChatPayload({ id, payload, force = false }) {
     }));
 }
 
-export async function saveGroupChatPayloadWindowed({ id, cursor, payload, force = false }) {
+export async function saveGroupChatPayloadWindowed({ id, cursor, payload, expectedWindowLineCount, force = false }) {
     const normalizedId = normalizeChatFileName(id);
     if (!Array.isArray(payload) || payload.length === 0 || !normalizedId.trim()) {
         throw new Error('Invalid group chat payload');
@@ -364,12 +374,13 @@ export async function saveGroupChatPayloadWindowed({ id, cursor, payload, force 
             cursor,
             header,
             lines,
+            expected_window_line_count: normalizeExpectedWindowLineCount(expectedWindowLineCount),
             force,
         },
     });
 }
 
-export async function patchGroupChatPayloadWindowed({ id, cursor, header, patch, force = false }) {
+export async function patchGroupChatPayloadWindowed({ id, cursor, header, patch, expectedWindowLineCount, force = false }) {
     const normalizedId = normalizeChatFileName(id);
     if (!normalizedId.trim()) {
         throw new Error('Invalid group chat payload patch request');
@@ -381,6 +392,7 @@ export async function patchGroupChatPayloadWindowed({ id, cursor, header, patch,
             cursor,
             header: String(header),
             patch,
+            expected_window_line_count: normalizeExpectedWindowLineCount(expectedWindowLineCount),
             force,
         },
     });

--- a/src/scripts/tauri/chat/windowed-state.js
+++ b/src/scripts/tauri/chat/windowed-state.js
@@ -122,5 +122,9 @@ export function buildWindowedPayloadPatch(messages, windowState, label = 'chat')
         patch,
         savedMessageCount: messages.length,
         dirtyFromIndex: messages.length,
+        // Window baseline contract: how many message lines the last successful
+        // load/save left between cursor.offset and EOF. The backend rejects the
+        // write if the file no longer matches.
+        expectedWindowLineCount: savedMessageCount,
     };
 }

--- a/tests/windowed-payload-guards-contract.test.mjs
+++ b/tests/windowed-payload-guards-contract.test.mjs
@@ -98,7 +98,7 @@ test('windowed payload: windowed patch commit is guarded and merges cursor offse
 
     const saveGroupStart = groupChats.indexOf('async function saveGroupChat');
     assert.ok(saveGroupStart >= 0);
-    const saveGroupSlice = groupChats.slice(saveGroupStart, saveGroupStart + 2400);
+    const saveGroupSlice = groupChats.slice(saveGroupStart, saveGroupStart + 2600);
 
     assert.match(saveGroupSlice, /\bgetWindowedChatKey\b/);
     assert.match(saveGroupSlice, /const\s+expectedCursorOffset\s*=\s*windowState\.cursor\.offset\s*;/);

--- a/tests/windowed-payload-guards-contract.test.mjs
+++ b/tests/windowed-payload-guards-contract.test.mjs
@@ -6,6 +6,46 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+/**
+ * Extract a function body by brace-balancing from a header marker, so a guard
+ * assertion can't be silently defeated by the function growing past a fixed
+ * character window. Returns the slice from the marker through the matching
+ * closing brace of the first `{` after it.
+ */
+function extractFunctionBody(source, marker) {
+    const start = source.indexOf(marker);
+    assert.ok(start >= 0, `marker not found: ${marker}`);
+
+    // Skip the parameter list first — a destructured signature like
+    // `fn({ a, b } = {})` has braces that would otherwise be matched as the
+    // body. Balance the signature parentheses to find where params end.
+    const paramOpen = source.indexOf('(', start);
+    assert.ok(paramOpen >= 0, `no parameter list after: ${marker}`);
+    let parenDepth = 0;
+    let paramEnd = -1;
+    for (let i = paramOpen; i < source.length; i += 1) {
+        if (source[i] === '(') parenDepth += 1;
+        else if (source[i] === ')') {
+            parenDepth -= 1;
+            if (parenDepth === 0) { paramEnd = i; break; }
+        }
+    }
+    assert.ok(paramEnd >= 0, `unbalanced parameter list: ${marker}`);
+
+    const open = source.indexOf('{', paramEnd);
+    assert.ok(open >= 0, `no function body after: ${marker}`);
+    let depth = 0;
+    for (let i = open; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '{') depth += 1;
+        else if (ch === '}') {
+            depth -= 1;
+            if (depth === 0) return source.slice(start, i + 1);
+        }
+    }
+    throw new Error(`unbalanced braces from marker: ${marker}`);
+}
+
 test('windowed payload: showMoreMessages implements single-flight + CAS commit', async () => {
     const source = await readFile(path.join(REPO_ROOT, 'src/script.js'), 'utf8');
 
@@ -84,27 +124,21 @@ test('windowed payload: windowed patch commit is guarded and merges cursor offse
     const script = await readFile(path.join(REPO_ROOT, 'src/script.js'), 'utf8');
     const groupChats = await readFile(path.join(REPO_ROOT, 'src/scripts/group-chats.js'), 'utf8');
 
-    const saveChatStart = script.indexOf('export async function saveChat');
-    assert.ok(saveChatStart >= 0);
-    const saveChatSlice = script.slice(saveChatStart, saveChatStart + 3200);
+    // Brace-balanced extraction: a guard can't be defeated by the function
+    // growing past a fixed character window (which already broke once).
+    const saveChatSlice = extractFunctionBody(script, 'async function saveChatUnsafe');
+    const saveGroupSlice = extractFunctionBody(groupChats, 'async function saveGroupChatUnsafe');
 
-    assert.match(saveChatSlice, /\bgetWindowedChatKey\b/);
-    assert.match(saveChatSlice, /const\s+expectedCursorOffset\s*=\s*windowState\.cursor\.offset\s*;/);
-    assert.match(
-        saveChatSlice,
-        /mergeWindowedChatCursorOffset\(\s*activeWindowState\?\.\s*cursor\s*,\s*cursor\s*,\s*expectedCursorOffset\s*\)/,
-    );
-    assert.match(saveChatSlice, /activeWindowState\?\.\s*cursor\?\.\s*offset\s*===\s*expectedCursorOffset/);
-
-    const saveGroupStart = groupChats.indexOf('async function saveGroupChat');
-    assert.ok(saveGroupStart >= 0);
-    const saveGroupSlice = groupChats.slice(saveGroupStart, saveGroupStart + 2600);
-
-    assert.match(saveGroupSlice, /\bgetWindowedChatKey\b/);
-    assert.match(saveGroupSlice, /const\s+expectedCursorOffset\s*=\s*windowState\.cursor\.offset\s*;/);
-    assert.match(
-        saveGroupSlice,
-        /mergeWindowedChatCursorOffset\(\s*activeWindowState\?\.\s*cursor\s*,\s*cursor\s*,\s*expectedCursorOffset\s*\)/,
-    );
-    assert.match(saveGroupSlice, /activeWindowState\?\.\s*cursor\?\.\s*offset\s*===\s*expectedCursorOffset/);
+    for (const slice of [saveChatSlice, saveGroupSlice]) {
+        assert.match(slice, /\bgetWindowedChatKey\b/);
+        assert.match(slice, /const\s+expectedCursorOffset\s*=\s*windowState\.cursor\.offset\s*;/);
+        assert.match(
+            slice,
+            /mergeWindowedChatCursorOffset\(\s*activeWindowState\?\.\s*cursor\s*,\s*cursor\s*,\s*expectedCursorOffset\s*\)/,
+        );
+        assert.match(slice, /activeWindowState\?\.\s*cursor\?\.\s*offset\s*===\s*expectedCursorOffset/);
+        // Window baseline contract: the patch call must forward the declared
+        // line count, or the backend can't reject a stale cursor.
+        assert.match(slice, /expectedWindowLineCount/);
+    }
 });

--- a/tests/windowed-payload-state.test.mjs
+++ b/tests/windowed-payload-state.test.mjs
@@ -131,6 +131,8 @@ test('windowed-state: buildWindowedPayloadPatch rewriteFromIndex when dirtyFromI
     assert.deepEqual(result.patch.lines, messages.slice(2).map((entry) => JSON.stringify(entry)));
     assert.equal(result.savedMessageCount, messages.length);
     assert.equal(result.dirtyFromIndex, messages.length);
+    // Window baseline contract: declares the PRE-write on-disk line count, not the new one.
+    assert.equal(result.expectedWindowLineCount, 5);
 });
 
 test('windowed-state: buildWindowedPayloadPatch truncates when messages shorter than savedMessageCount', async () => {
@@ -144,6 +146,7 @@ test('windowed-state: buildWindowedPayloadPatch truncates when messages shorter 
     assert.deepEqual(result.patch, { kind: 'rewriteFromIndex', startIndex: 3, lines: [] });
     assert.equal(result.savedMessageCount, messages.length);
     assert.equal(result.dirtyFromIndex, messages.length);
+    assert.equal(result.expectedWindowLineCount, 5);
 });
 
 test('windowed-state: buildWindowedPayloadPatch appends when messages longer than savedMessageCount', async () => {
@@ -158,6 +161,9 @@ test('windowed-state: buildWindowedPayloadPatch appends when messages longer tha
     assert.deepEqual(result.patch.lines, messages.slice(3).map((entry) => JSON.stringify(entry)));
     assert.equal(result.savedMessageCount, messages.length);
     assert.equal(result.dirtyFromIndex, messages.length);
+    // Append must declare the OLD count (3) so the backend rejects a stale
+    // cursor whose window no longer holds 3 lines — not the post-append count.
+    assert.equal(result.expectedWindowLineCount, 3);
 });
 
 test('windowed-state: buildWindowedPayloadPatch full rewrite when unchanged but non-empty', async () => {
@@ -183,6 +189,42 @@ test('windowed-state: buildWindowedPayloadPatch returns empty append for empty m
     assert.deepEqual(result.patch, { kind: 'append', lines: [] });
     assert.equal(result.savedMessageCount, 0);
     assert.equal(result.dirtyFromIndex, 0);
+    assert.equal(result.expectedWindowLineCount, 0);
+});
+
+test('windowed-state: buildWindowedPayloadPatch baseline always equals the pre-write savedMessageCount', async () => {
+    const mod = await importFresh(path.join(REPO_ROOT, 'src/scripts/tauri/chat/windowed-state.js'));
+    const { buildWindowedPayloadPatch } = mod;
+
+    // The contract the backend relies on: expectedWindowLineCount is the line
+    // count the window had on disk BEFORE this write, regardless of which patch
+    // branch is taken (append / rewrite / truncate / full). If this ever drifts
+    // to messages.length, every stale-cursor write would be silently accepted.
+    const cases = [
+        { messages: 5, savedMessageCount: 5, dirtyFromIndex: 2 }, // rewriteFromIndex
+        { messages: 3, savedMessageCount: 5, dirtyFromIndex: 5 }, // truncate
+        { messages: 5, savedMessageCount: 3, dirtyFromIndex: 3 }, // append
+        { messages: 2, savedMessageCount: 2, dirtyFromIndex: 2 }, // full rewrite
+        { messages: 0, savedMessageCount: 0, dirtyFromIndex: 0 }, // empty
+    ];
+
+    for (const { messages, savedMessageCount, dirtyFromIndex } of cases) {
+        const result = buildWindowedPayloadPatch(
+            buildMessages(messages),
+            { savedMessageCount, dirtyFromIndex },
+            'chat',
+        );
+        assert.equal(
+            result.expectedWindowLineCount,
+            savedMessageCount,
+            `baseline must equal pre-write savedMessageCount=${savedMessageCount}, got ${result.expectedWindowLineCount}`,
+        );
+        assert.notEqual(
+            result.expectedWindowLineCount === messages && messages !== savedMessageCount,
+            true,
+            'baseline must not drift to the post-write message count',
+        );
+    }
 });
 
 test('windowed-state: shiftWindowedMessageSaveState shifts counters without mutating original', async () => {


### PR DESCRIPTION
## Problem

在全量和分片聊天加载模式之间切换时，会**静默丢失聊天记录**。cursor offset 和实际窗口之间的不匹配导致 `set_len()` 在错误位置截断文件。

### Root cause

`verify_cursor_signature()` 只检查 `(file_size, modified_millis)`，**不验证 `cursor.offset`**。切换模式时：

1. **全量模式** cursor：`offset` 靠近 header 末尾（加载了所有消息）
2. **分片模式** cursor：`offset` 靠近文件末尾（只加载最后 ~100 条消息）

由于两次加载之间文件没有变化，两个 cursor 共享**相同的** `(size, modified_millis)` 签名——检查通过。但 offset 完全不同。

当 save 使用了错误的 cursor：

- **全量→分片**：`set_len(header_end)` + 写入 100 条尾部消息 → **所有中间消息被销毁**
- **分片→全量**：`set_len(near_EOF)` + 写入 300 条消息 → **250 条消息重复，文件损坏**

### 实际影响

我在 Android 上从分片切换到全量模式后，丢失了**一周的聊天记录**（约 5月30日到6月6日）。默认窗口大小 100 条消息，最终只有最后 100 条幸存。备份系统也只包含截断后的快照，因为备份是在数据损坏之后创建的。

观察到的错误：
```
Cursor signature mismatch for "/storage/emulated/0/Android/data/com.tauritavern.client/data/default-user/chats/…/… - 2026-05-30@22h54m59s329ms.jsonl"
```

### 复现（300 条消息压力测试）

```
=== Full → Windowed ===
Full cursor offset:     93
Windowed cursor offset: 528483
Data at risk: 528390 bytes
修复前: DATA LOSS: 301 → 51 lines (250 messages destroyed!)
修复后: Save correctly rejected, all 300 messages safe.

=== Windowed → Full ===
Windowed cursor offset: 528481
Full cursor offset:     91
修复前: CORRUPTION: 250 duplicate message lines!
修复后: Save correctly rejected, all 300 messages safe.
```

## Fix

在 `windowed_payload_io.rs` 中添加 `verify_window_line_consistency()`。在任何 `set_len()` 截断之前，统计磁盘上窗口区域的实际行数，并与要写入的行数进行比较。如果差异超过 `max(20, 50%)`，则拒绝保存并返回描述性错误，提示用户重新加载聊天。

此检查在 `save_payload_windowed_internal`（windowed_payload.rs）和 `patch_payload_windowed_internal` 的 RewriteFromIndex 路径（windowed_patch.rs）中均有调用，覆盖了所有截断代码路径。

### 修改文件

- `windowed_payload_io.rs` — 添加 `count_lines_in_region()` 和 `verify_window_line_consistency()`
- `windowed_payload.rs` — 在 `set_len()` 前调用验证（`!header_changed` 和 `header_changed` 两个分支）
- `windowed_patch.rs` — 在 `RewriteFromIndex` 的 `set_len()` 前调用验证

### 设计决策

- **无 cursor 结构变更**：完全向后兼容，无需前端改动
- **容差阈值**：`max(20, 50%)` 允许正常编辑（增删几条消息）同时捕获模式切换不匹配（50 vs 300 行）
- **启发式而非密码学**：cursor 中的内容哈希会更精确，但需要结构变更和前端配合。行数检查以零兼容性风险捕获了真实的故障模式

Relates to #87