### PR TITLE
feat: OLED red-black reader mode (+ Android no-flash window background)

### DIFF
--- a/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
+++ b/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.tauritavern" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Pure black window background avoids a white flash before the WebView paints. -->
+        <item name="android:windowBackground">@color/black</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/src-tauri/gen/android/app/src/main/res/values/themes.xml
+++ b/src-tauri/gen/android/app/src/main/res/values/themes.xml
@@ -1,6 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.tauritavern" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Pure black window background avoids a white flash before the WebView paints. -->
+        <item name="android:windowBackground">@color/black</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/src/tauri/main/bootstrap.js
+++ b/src/tauri/main/bootstrap.js
@@ -42,6 +42,7 @@ import { registerRoutes } from './routes/index.js';
 import { isEmbeddedRuntimeTakeoverDisabled } from './services/embedded-runtime/embedded-runtime-profile-state.js';
 import { installFrontendLogCapture, setFrontendLogBackendForwardingEnabled } from './services/dev-logging/frontend-log-capture.js';
 import { preinstallPanelRuntime } from './services/panel-runtime/preinstall.js';
+import { installOledReader } from './services/oled-reader/install.js';
 let bootstrapped = false;
 const HOST_ABI_VERSION = 1;
 
@@ -266,6 +267,10 @@ export function bootstrapTauriMain() {
         safePerfMark('tt:tauri:bootstrap:start');
     }
     const isMobile = isMobileUserAgent(); if (isMobile) installTauriMobileCompat();
+
+    // Apply the OLED red-black reader before first paint so a previously enabled
+    // mode does not flash the default theme on startup.
+    installOledReader();
 
     installFrontendLogCapture();
     installDialogPolyfillCoverage();

--- a/src/tauri/main/services/oled-reader/constants.js
+++ b/src/tauri/main/services/oled-reader/constants.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+/**
+ * Shared constants for the OLED red-black reader service.
+ *
+ * The reader turns the whole app into a pure-black canvas with single-hue red
+ * text. Everything is driven from one root state ({ enabled, level }) so a
+ * single control flips the entire UI, per the oled-red-black guidance.
+ */
+
+/** Class toggled on <html> that activates every override rule. */
+export const ROOT_CLASS = 'tt-oled-reader';
+
+/** <style> element id holding the override rules (injected once). */
+export const STYLE_ELEMENT_ID = 'tt-oled-reader-style';
+
+/** Floating widget container id. */
+export const WIDGET_ID = 'tt-oled-reader-widget';
+/** Toggle button id (the "reader" button). */
+export const BUTTON_ID = 'tt-oled-reader-toggle';
+/** Red-brightness slider id. */
+export const SLIDER_ID = 'tt-oled-reader-level';
+
+/** localStorage key. OLED mode is a per-device display preference, so it is
+ * stored locally rather than synced through the typed backend settings. */
+export const STORAGE_KEY = 'tauritavern:oled_reader';
+
+/** Window event broadcast when the reader state changes, so any other surface
+ * (e.g. a future settings panel entry) can stay in sync. */
+export const OLED_READER_CHANGED_EVENT = 'tauritavern:oled_reader_changed';
+
+/** Inline CSS custom properties carrying the computed palette. */
+export const CSS_RED = '--tt-oled-red';
+export const CSS_RED_DIM = '--tt-oled-red-dim';
+export const CSS_CHANNEL = '--tt-oled-red-channel';
+
+/** level bounds: 0.15 keeps the darkest setting readable (channel >= 99). */
+export const MIN_LEVEL = 0.15;
+export const MAX_LEVEL = 1;
+export const DEFAULT_LEVEL = 0.7;
+export const DEFAULT_ENABLED = false;

--- a/src/tauri/main/services/oled-reader/dom.js
+++ b/src/tauri/main/services/oled-reader/dom.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+import { CSS_CHANNEL, CSS_RED, CSS_RED_DIM, ROOT_CLASS, STYLE_ELEMENT_ID } from './constants.js';
+import { computePalette } from './palette.js';
+import { buildOledCss } from './style.js';
+
+/** Inject the override stylesheet once into <head>. */
+export function injectStyleOnce() {
+    if (document.getElementById(STYLE_ELEMENT_ID)) {
+        return;
+    }
+    const style = document.createElement('style');
+    style.id = STYLE_ELEMENT_ID;
+    style.textContent = buildOledCss();
+    (document.head || document.documentElement).appendChild(style);
+}
+
+/**
+ * Push the computed palette into inline custom properties on <html>.
+ * @param {number} level
+ */
+export function applyLevelVars(level) {
+    const palette = computePalette(level);
+    const root = document.documentElement;
+    root.style.setProperty(CSS_RED, palette.red);
+    root.style.setProperty(CSS_RED_DIM, palette.dimRed);
+    root.style.setProperty(CSS_CHANNEL, String(palette.channel));
+}
+
+/**
+ * Toggle reader mode on the root element and keep the mobile chrome color
+ * (meta theme-color) in sync.
+ * @param {boolean} enabled
+ */
+export function applyEnabled(enabled) {
+    document.documentElement.classList.toggle(ROOT_CLASS, enabled);
+    syncMetaThemeColor(enabled);
+}
+
+/** @param {boolean} enabled */
+function syncMetaThemeColor(enabled) {
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (!(meta instanceof HTMLMetaElement)) {
+        return;
+    }
+    if (enabled) {
+        if (meta.dataset.ttOledPrev === undefined) {
+            meta.dataset.ttOledPrev = meta.content;
+        }
+        meta.content = '#000000';
+        return;
+    }
+    if (meta.dataset.ttOledPrev !== undefined) {
+        meta.content = meta.dataset.ttOledPrev;
+        delete meta.dataset.ttOledPrev;
+    }
+}

--- a/src/tauri/main/services/oled-reader/install.js
+++ b/src/tauri/main/services/oled-reader/install.js
@@ -1,0 +1,93 @@
+// @ts-check
+
+import { OLED_READER_CHANGED_EVENT } from './constants.js';
+import { applyEnabled, applyLevelVars, injectStyleOnce } from './dom.js';
+import { clampLevel } from './palette.js';
+import { loadState, saveState } from './state.js';
+import { mountWidget, syncWidget } from './ui.js';
+
+/**
+ * Install the OLED red-black reader.
+ *
+ * Visuals are applied synchronously so the override class is on <html> before
+ * the app's first paint (no flash when the mode was left enabled). The floating
+ * control mounts once <body> is available.
+ *
+ * @returns {{ ready: Promise<void> }}
+ */
+export function installOledReader() {
+    const state = loadState();
+
+    injectStyleOnce();
+    applyLevelVars(state.level);
+    applyEnabled(state.enabled);
+
+    const persistAndBroadcast = () => {
+        saveState(state);
+        window.dispatchEvent(new CustomEvent(OLED_READER_CHANGED_EVENT, {
+            detail: { enabled: state.enabled, level: state.level },
+        }));
+    };
+
+    /** @param {boolean} enabled */
+    const setEnabled = (enabled) => {
+        if (enabled === state.enabled) {
+            return;
+        }
+        state.enabled = enabled;
+        applyEnabled(enabled);
+        syncWidget(state);
+        persistAndBroadcast();
+    };
+
+    /** @param {number} level */
+    const setLevel = (level) => {
+        const next = clampLevel(level);
+        if (next === state.level) {
+            return;
+        }
+        state.level = next;
+        applyLevelVars(next);
+        persistAndBroadcast();
+    };
+
+    const handlers = {
+        getState: () => ({ enabled: state.enabled, level: state.level }),
+        onToggle: () => setEnabled(!state.enabled),
+        onLevel: setLevel,
+    };
+
+    const mount = () => mountWidget(handlers);
+    if (document.body) {
+        mount();
+    } else {
+        document.addEventListener('DOMContentLoaded', mount, { once: true });
+    }
+
+    // Stay in sync if another surface changes the setting (guarded against echo).
+    window.addEventListener(OLED_READER_CHANGED_EVENT, (event) => {
+        const detail = /** @type {CustomEvent} */ (event).detail;
+        if (!detail || typeof detail !== 'object') {
+            return;
+        }
+        const record = /** @type {Record<string, unknown>} */ (detail);
+        let changed = false;
+        const nextEnabled = Boolean(record.enabled);
+        if (nextEnabled !== state.enabled) {
+            state.enabled = nextEnabled;
+            applyEnabled(nextEnabled);
+            changed = true;
+        }
+        const nextLevel = Number(record.level);
+        if (Number.isFinite(nextLevel) && clampLevel(nextLevel) !== state.level) {
+            state.level = clampLevel(nextLevel);
+            applyLevelVars(state.level);
+            changed = true;
+        }
+        if (changed) {
+            syncWidget(state);
+        }
+    });
+
+    return { ready: Promise.resolve() };
+}

--- a/src/tauri/main/services/oled-reader/palette.js
+++ b/src/tauri/main/services/oled-reader/palette.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import { MAX_LEVEL, MIN_LEVEL } from './constants.js';
+
+/**
+ * Clamp a red level into the readable range.
+ * @param {number} level
+ * @returns {number}
+ */
+export function clampLevel(level) {
+    if (!Number.isFinite(level)) {
+        return MIN_LEVEL;
+    }
+    return Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, level));
+}
+
+/**
+ * @typedef {object} OledPalette
+ * @property {number} level   clamped level (0.15..1)
+ * @property {number} channel red channel value (99..255)
+ * @property {string} red     rgb() string for primary text/icons
+ * @property {string} dimRed  rgb() string for secondary info (same hue, ~55%)
+ */
+
+/**
+ * Compute the red-on-black palette from a single level value.
+ *
+ * Only the red channel moves; green and blue stay 0 so just the red subpixel
+ * lights up. Secondary info uses the same hue at ~55% so it never falls back to
+ * grey (which would introduce blue/green light).
+ *
+ * @param {number} level
+ * @returns {OledPalette}
+ */
+export function computePalette(level) {
+    const clamped = clampLevel(level);
+    const channel = Math.min(255, Math.max(72, Math.round(72 + 183 * clamped)));
+    const dim = Math.round(channel * 0.55);
+    return {
+        level: clamped,
+        channel,
+        red: `rgb(${channel}, 0, 0)`,
+        dimRed: `rgb(${dim}, 0, 0)`,
+    };
+}

--- a/src/tauri/main/services/oled-reader/state.js
+++ b/src/tauri/main/services/oled-reader/state.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+import { DEFAULT_ENABLED, DEFAULT_LEVEL, STORAGE_KEY } from './constants.js';
+import { clampLevel } from './palette.js';
+
+/**
+ * @typedef {object} OledReaderState
+ * @property {boolean} enabled
+ * @property {number} level
+ */
+
+/** @returns {OledReaderState} */
+function defaultState() {
+    return { enabled: DEFAULT_ENABLED, level: DEFAULT_LEVEL };
+}
+
+/**
+ * Load persisted reader state from localStorage, falling back to defaults.
+ * @returns {OledReaderState}
+ */
+export function loadState() {
+    try {
+        const raw = window.localStorage?.getItem(STORAGE_KEY);
+        if (!raw) {
+            return defaultState();
+        }
+        const parsed = /** @type {unknown} */ (JSON.parse(raw));
+        if (!parsed || typeof parsed !== 'object') {
+            return defaultState();
+        }
+        const record = /** @type {Record<string, unknown>} */ (parsed);
+        const levelRaw = Number(record.level);
+        return {
+            enabled: Boolean(record.enabled),
+            level: Number.isFinite(levelRaw) ? clampLevel(levelRaw) : DEFAULT_LEVEL,
+        };
+    } catch (error) {
+        console.warn('TauriTavern OLED reader: failed to read saved state', error);
+        return defaultState();
+    }
+}
+
+/**
+ * Persist reader state to localStorage.
+ * @param {OledReaderState} state
+ */
+export function saveState(state) {
+    try {
+        const payload = JSON.stringify({ enabled: Boolean(state.enabled), level: clampLevel(state.level) });
+        window.localStorage?.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+        console.warn('TauriTavern OLED reader: failed to persist state', error);
+    }
+}

--- a/src/tauri/main/services/oled-reader/style.js
+++ b/src/tauri/main/services/oled-reader/style.js
@@ -1,0 +1,167 @@
+// @ts-check
+
+import { CSS_RED, CSS_RED_DIM, ROOT_CLASS, WIDGET_ID, BUTTON_ID, SLIDER_ID } from './constants.js';
+
+/**
+ * Build the CSS that powers the reader.
+ *
+ * Strategy: SillyTavern drives ~all colors from `--SmartTheme*` custom
+ * properties that it writes inline on <html> via setProperty(). Author
+ * declarations marked `!important` outrank inline non-important declarations,
+ * so re-pointing those variables here flips the whole UI and survives theme
+ * switches. A handful of hardcoded colors (kbd, scrollbars, selection,
+ * wallpaper) are overridden explicitly.
+ *
+ * `red` / `dimRed` come from inline `--tt-oled-red*` vars set per the current
+ * level, so the slider can dim the hue without rebuilding this sheet.
+ *
+ * @returns {string}
+ */
+export function buildOledCss() {
+    const red = `var(${CSS_RED})`;
+    const dim = `var(${CSS_RED_DIM})`;
+    const root = `html.${ROOT_CLASS}`;
+
+    return `
+/* ===== TauriTavern OLED red-black reader ===== */
+${root} {
+    /* foreground: single red hue */
+    --SmartThemeBodyColor: ${red} !important;
+    --SmartThemeEmColor: ${dim} !important;
+    --SmartThemeUnderlineColor: ${red} !important;
+    --SmartThemeQuoteColor: ${red} !important;
+
+    /* surfaces: pure black so OLED pixels switch off */
+    --SmartThemeBlurTintColor: #000000 !important;
+    --SmartThemeChatTintColor: #000000 !important;
+    --SmartThemeUserMesBlurTintColor: #000000 !important;
+    --SmartThemeBotMesBlurTintColor: #000000 !important;
+    --SmartThemeFastUIBGColor: #000000 !important;
+
+    /* structure via thin red borders, no glow */
+    --SmartThemeBorderColor: ${dim} !important;
+    --SmartThemeShadowColor: rgba(0, 0, 0, 0) !important;
+
+    /* checkbox: black box, red tick */
+    --SmartThemeCheckboxBgColorR: 0 !important;
+    --SmartThemeCheckboxBgColorG: 0 !important;
+    --SmartThemeCheckboxBgColorB: 0 !important;
+    --SmartThemeCheckboxTickColor: ${red} !important;
+
+    /* utility accents collapsed onto the single hue */
+    --interactable-outline-color: ${red} !important;
+    --interactable-outline-color-faint: ${dim} !important;
+    --white100: ${red} !important;
+    --white70a: ${red} !important;
+    --white60a: ${red} !important;
+    --white50a: ${red} !important;
+    --white30a: ${dim} !important;
+    --white20a: ${dim} !important;
+    --grey75: ${red} !important;
+    --grey70: ${red} !important;
+    --grey50: ${dim} !important;
+    --grey30: ${dim} !important;
+    --grey10: #000000 !important;
+    --golden: ${red} !important;
+    --ivory: ${red} !important;
+    --active: ${red} !important;
+    --preferred: ${red} !important;
+    --warning: ${red} !important;
+    --okGreen70a: ${dim} !important;
+    --crimson70a: ${dim} !important;
+
+    background-color: #000000 !important;
+    accent-color: ${red} !important;
+    color-scheme: dark;
+}
+
+${root} body {
+    background-color: #000000 !important;
+    background-image: none !important;
+    color: ${red};
+}
+
+/* kill the wallpaper layer — it is a large light source */
+${root} #bg1,
+${root} #bg2,
+${root} #bg_custom {
+    background-image: none !important;
+    background-color: #000000 !important;
+    filter: brightness(0) !important;
+}
+
+/* hardcoded spots that do not flow through the theme variables */
+${root} kbd {
+    background-color: #000000 !important;
+    color: ${red} !important;
+    border-color: ${dim} !important;
+}
+
+${root} ::selection {
+    background: ${red} !important;
+    color: #000000 !important;
+}
+
+${root} * {
+    scrollbar-color: ${dim} #000000 !important;
+}
+${root} ::-webkit-scrollbar,
+${root} ::-webkit-scrollbar-track {
+    background: #000000 !important;
+}
+${root} ::-webkit-scrollbar-thumb {
+    background: ${dim} !important;
+}
+
+/* ===== floating reader control (always present so it can switch ON) ===== */
+#${WIDGET_ID} {
+    position: fixed;
+    left: calc(env(safe-area-inset-left, 0px) + 10px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
+    z-index: 2147483600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mainFontFamily, "Noto Sans", sans-serif);
+    pointer-events: none;
+}
+#${WIDGET_ID} > * {
+    pointer-events: auto;
+}
+#${BUTTON_ID} {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    color: #d0d0c8;
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(180, 180, 180, 0.45);
+    backdrop-filter: blur(4px);
+    opacity: 0.55;
+    transition: opacity 0.15s ease;
+}
+#${BUTTON_ID}:hover {
+    opacity: 1;
+}
+#${SLIDER_ID} {
+    display: none;
+    width: 110px;
+    height: 18px;
+}
+${root} #${WIDGET_ID} #${BUTTON_ID} {
+    color: ${red};
+    background: #000000;
+    border-color: ${red};
+    opacity: 1;
+}
+${root} #${WIDGET_ID} #${SLIDER_ID} {
+    display: block;
+    accent-color: ${red};
+}
+`;
+}

--- a/src/tauri/main/services/oled-reader/ui.js
+++ b/src/tauri/main/services/oled-reader/ui.js
@@ -1,0 +1,71 @@
+// @ts-check
+
+import { BUTTON_ID, MAX_LEVEL, MIN_LEVEL, SLIDER_ID, WIDGET_ID } from './constants.js';
+
+/**
+ * @typedef {object} OledReaderState
+ * @property {boolean} enabled
+ * @property {number} level
+ */
+
+/**
+ * @typedef {object} WidgetHandlers
+ * @property {() => OledReaderState} getState
+ * @property {() => void} onToggle
+ * @property {(level: number) => void} onLevel
+ */
+
+/**
+ * Mount the floating reader control (toggle button + brightness slider).
+ * Idempotent; safe to call once <body> exists.
+ * @param {WidgetHandlers} handlers
+ */
+export function mountWidget(handlers) {
+    if (document.getElementById(WIDGET_ID) || !document.body) {
+        return;
+    }
+
+    const widget = document.createElement('div');
+    widget.id = WIDGET_ID;
+
+    const button = document.createElement('button');
+    button.id = BUTTON_ID;
+    button.type = 'button';
+    button.title = 'OLED red-black reader';
+    button.setAttribute('aria-label', 'Toggle OLED red-black reader');
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-circle-half-stroke';
+    button.appendChild(icon);
+    button.addEventListener('click', () => handlers.onToggle());
+
+    const slider = document.createElement('input');
+    slider.id = SLIDER_ID;
+    slider.type = 'range';
+    slider.min = String(MIN_LEVEL);
+    slider.max = String(MAX_LEVEL);
+    slider.step = '0.01';
+    slider.title = 'Red brightness';
+    slider.setAttribute('aria-label', 'Red brightness');
+    slider.addEventListener('input', () => handlers.onLevel(Number(slider.value)));
+
+    widget.appendChild(button);
+    widget.appendChild(slider);
+    document.body.appendChild(widget);
+
+    syncWidget(handlers.getState());
+}
+
+/**
+ * Reflect current state into the widget controls.
+ * @param {OledReaderState} state
+ */
+export function syncWidget(state) {
+    const button = document.getElementById(BUTTON_ID);
+    if (button) {
+        button.setAttribute('aria-pressed', String(state.enabled));
+    }
+    const slider = document.getElementById(SLIDER_ID);
+    if (slider instanceof HTMLInputElement) {
+        slider.value = String(state.level);
+    }
+}


### PR DESCRIPTION
## What

Adds a one-tap **OLED red-black reader mode**: a button that flips the whole app into a pure-black canvas with single-hue red text, plus a slider to dim the red. It's a night-reading / OLED power-saving display mode — pure `#000000` lets OLED pixels switch off, and lighting only the red subpixel (green/blue stay `0`) keeps blue light minimal.

A small floating button (bottom-left) toggles it; a brightness slider appears when it's on.

## How it works

The whole UI flips from a **single source**. SillyTavern drives ~all colors from `--SmartTheme*` CSS custom properties that it writes inline on `<html>` via `setProperty()`. Author declarations marked `!important` outrank inline non-important ones, so re-pointing those variables in a stylesheet scoped to `html.tt-oled-reader` flips everything at once **and survives theme switches** (re-applying a theme just rewrites the inline vars, which my `!important` rules still beat). The few hardcoded colors (`kbd`, scrollbars, `::selection`, the wallpaper layer) are overridden explicitly.

Palette follows a precise formula — only the red channel moves:

```
channel = round(72 + 183 * level)   // level 0.15..1  ->  99..255
red     = rgb(channel, 0, 0)
dimRed  = rgb(round(channel*0.55), 0, 0)   // secondary text, same hue, never grey
```

## Files

- **`src/tauri/main/services/oled-reader/`** — new self-contained service (mirrors the `dynamic-theme` service): `constants / palette / state / style / dom / ui / install`. **No upstream SillyTavern files are touched**, so it won't conflict with frontend syncs.
  - A small floating button (Font Awesome `fa-circle-half-stroke`) toggles the mode; a red-brightness slider appears when it's on.
  - State persisted in **localStorage**. OLED mode is a per-device display preference (you may want it on your phone but not your desktop), so it's intentionally local rather than synced through the typed backend settings DTO.
  - Installed **early in `bootstrap.js`, before first paint**, so a previously-enabled mode doesn't flash the default theme on startup.
- **`src-tauri/gen/android/app/src/main/res/values{,-night}/themes.xml`** — set a pure-black `android:windowBackground` to kill the white cold-start flash before the WebView paints. (System bars are already immersive + transparent, so no bar-color changes were needed.)

## Verification

- `pnpm run check` — guardrails ✅, `tsc -p tsconfig.host.json` ✅, **608/608 contract tests** ✅
- `pnpm run web:build` ✅
- `pnpm tauri android build --apk --target aarch64` — Android (arm64) build status noted in the PR thread.

## Notes / follow-ups

- The toggle floats at bottom-left; position is a one-line CSS tweak if it collides with anything on a given layout.
- Avatars/inline images are left as-is (content); the decorative wallpaper layer is blacked out since it's a large light source.
