### PR TITLE
Handle missing empty persistent roots

### DIFF
--- a/src-tauri/src/infrastructure/repositories/file_agent_repository/persistent_store.rs
+++ b/src-tauri/src/infrastructure/repositories/file_agent_repository/persistent_store.rs
@@ -97,20 +97,25 @@ impl FileAgentRepository {
             })?;
             if let Some(base_state_dir) = base_state_dir.as_ref() {
                 let base_root = base_state_dir.join(&root);
-                let metadata = fs::symlink_metadata(&base_root).await.map_err(|error| {
-                    if error.kind() == std::io::ErrorKind::NotFound {
-                        DomainError::InvalidData(format!(
+                let metadata = match fs::symlink_metadata(&base_root).await {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        if !persistent_manifest_has_files_for_root(&manifest, &root) {
+                            continue;
+                        }
+                        return Err(DomainError::InvalidData(format!(
                             "agent.persistent_state_root_missing: state `{}` is missing root `{root}`",
                             run.persist_base_state_id.as_deref().unwrap_or_default()
-                        ))
-                    } else {
-                        DomainError::InternalError(format!(
+                        )));
+                    }
+                    Err(error) => {
+                        return Err(DomainError::InternalError(format!(
                             "Failed to inspect persistent state root {}: {}",
                             base_root.display(),
                             error
-                        ))
+                        )));
                     }
-                })?;
+                };
                 if metadata.file_type().is_symlink() || !metadata.is_dir() {
                     return Err(DomainError::InvalidData(format!(
                         "agent.persistent_state_root_invalid: {}",
@@ -346,4 +351,9 @@ pub(super) fn persistent_roots(manifest: &WorkspaceManifest) -> Result<Vec<Strin
         roots.push(validate_workspace_root_path(&root.path)?);
     }
     Ok(roots)
+}
+
+fn persistent_manifest_has_files_for_root(manifest: &PersistentStateManifest, root: &str) -> bool {
+    let prefix = format!("{root}/");
+    manifest.files.iter().any(|file| file.path.starts_with(&prefix))
 }

--- a/src-tauri/src/infrastructure/repositories/file_agent_repository/persistent_store.rs
+++ b/src-tauri/src/infrastructure/repositories/file_agent_repository/persistent_store.rs
@@ -64,23 +64,23 @@ impl FileAgentRepository {
             ))
         })?;
 
-        let base_state_dir = match run.persist_base_state_id.as_deref() {
+        let base_state = match run.persist_base_state_id.as_deref() {
             Some(state_id) => {
                 let state_dir = self.persistent_state_dir(&run.workspace_id, state_id)?;
-                let manifest = self.read_persistent_state_manifest(&state_dir).await?;
-                if manifest.state_id != state_id {
+                let state_manifest = self.read_persistent_state_manifest(&state_dir).await?;
+                if state_manifest.state_id != state_id {
                     return Err(DomainError::InvalidData(format!(
                         "agent.persistent_state_manifest_mismatch: manifest state `{}` does not match requested state `{state_id}`",
-                        manifest.state_id
+                        state_manifest.state_id
                     )));
                 }
-                if manifest.workspace_id != run.workspace_id {
+                if state_manifest.workspace_id != run.workspace_id {
                     return Err(DomainError::InvalidData(format!(
                         "agent.persistent_state_workspace_mismatch: state `{state_id}` belongs to workspace `{}`",
-                        manifest.workspace_id
+                        state_manifest.workspace_id
                     )));
                 }
-                Some(state_dir)
+                Some((state_dir, state_manifest))
             }
             None => None,
         };
@@ -95,12 +95,12 @@ impl FileAgentRepository {
                     error
                 ))
             })?;
-            if let Some(base_state_dir) = base_state_dir.as_ref() {
+            if let Some((base_state_dir, base_state_manifest)) = base_state.as_ref() {
                 let base_root = base_state_dir.join(&root);
                 let metadata = match fs::symlink_metadata(&base_root).await {
                     Ok(metadata) => metadata,
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        if !persistent_manifest_has_files_for_root(&manifest, &root) {
+                        if !persistent_manifest_has_files_for_root(base_state_manifest, &root) {
                             continue;
                         }
                         return Err(DomainError::InvalidData(format!(

--- a/src-tauri/src/infrastructure/repositories/file_agent_repository/tests.rs
+++ b/src-tauri/src/infrastructure/repositories/file_agent_repository/tests.rs
@@ -1092,6 +1092,70 @@ async fn delete_missing_chat_workspace_is_idempotent() {
 }
 
 #[tokio::test]
+async fn empty_persistent_state_restores_when_empty_root_directory_is_missing() {
+    let root = temp_root();
+    let repository = FileAgentRepository::new(root.clone());
+    let run = sample_run_with_id("run_empty_persist_base");
+    let manifest = sample_manifest(&run);
+    let profile = sample_resolved_profile(&manifest);
+
+    repository.create_run(&run).await.expect("create run");
+    repository
+        .initialize_run(
+            &run,
+            &manifest,
+            &serde_json::json!({"messages": []}),
+            &profile,
+        )
+        .await
+        .expect("initialize workspace");
+
+    let changes = repository
+        .commit_persistent_changes(&run.id)
+        .await
+        .expect("commit empty persist state");
+    assert!(changes.changes.is_empty());
+
+    let missing_empty_root = root
+        .join("chats")
+        .join(&run.workspace_id)
+        .join("persistent-states")
+        .join(&run.id)
+        .join("persist");
+    assert!(missing_empty_root.exists());
+    fs::remove_dir_all(&missing_empty_root)
+        .await
+        .expect("simulate sync dropping empty persist root");
+
+    let mut next_run = sample_run_with_id("run_empty_persist_child");
+    next_run.persist_base_state_id = Some(run.id.clone());
+    repository
+        .create_run(&next_run)
+        .await
+        .expect("create child run");
+    repository
+        .initialize_run(
+            &next_run,
+            &sample_manifest(&next_run),
+            &serde_json::json!({"messages": []}),
+            &profile,
+        )
+        .await
+        .expect("missing empty persist root should restore as empty");
+
+    assert!(
+        root.join("chats")
+            .join(&next_run.workspace_id)
+            .join("runs")
+            .join(&next_run.id)
+            .join("persist")
+            .exists()
+    );
+
+    fs::remove_dir_all(root).await.expect("cleanup");
+}
+
+#[tokio::test]
 async fn persistent_workspace_projects_run_changes_only_after_commit() {
     let root = temp_root();
     let repository = FileAgentRepository::new(root.clone());


### PR DESCRIPTION
Fixes #106

## Summary
- Treat missing persistent root directories as empty roots when the persistent-state manifest has no files for that root
- Keep existing error behavior when the persistent-state manifest references files under the missing root
- Add a regression test for sync/backup tools dropping empty `persist/` directories

## Tests
- `git diff --check`
- `cargo test empty_persistent_state_restores_when_empty_root_directory_is_missing --manifest-path src-tauri\Cargo.toml`