### PR TITLE
fix: apply custom body overrides before prompt caching

### DIFF
--- a/src-tauri/src/application/services/chat_completion_service/mod.rs
+++ b/src-tauri/src/application/services/chat_completion_service/mod.rs
@@ -369,6 +369,7 @@ impl ChatCompletionService {
         .await?;
         let payload = dto.payload;
         let (endpoint_path, mut upstream_payload) = payload::build_payload(source, payload)?;
+        additional_parameters.apply_body_overrides(&mut upstream_payload)?;
         self.apply_tauritavern_prompt_caching(
             source,
             &endpoint_path,
@@ -378,7 +379,6 @@ impl ChatCompletionService {
             prompt_caching_hints,
         )
         .await?;
-        additional_parameters.apply_body_overrides(&mut upstream_payload)?;
         payload::validate_upstream_tool_transcript(&endpoint_path, &upstream_payload)?;
 
         let response = self
@@ -481,6 +481,7 @@ impl ChatCompletionService {
         .await?;
         let payload = dto.payload;
         let (endpoint_path, mut upstream_payload) = payload::build_payload(source, payload)?;
+        additional_parameters.apply_body_overrides(&mut upstream_payload)?;
         self.apply_tauritavern_prompt_caching(
             source,
             &endpoint_path,
@@ -490,7 +491,6 @@ impl ChatCompletionService {
             prompt_caching_hints,
         )
         .await?;
-        additional_parameters.apply_body_overrides(&mut upstream_payload)?;
         payload::validate_upstream_tool_transcript(&endpoint_path, &upstream_payload)?;
 
         self.chat_completion_repository

--- a/tests/custom-claude-cache-order-contract.test.mjs
+++ b/tests/custom-claude-cache-order-contract.test.mjs
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const serviceSource = await readFile(
+    new URL('../src-tauri/src/application/services/chat_completion_service/mod.rs', import.meta.url),
+    'utf8',
+);
+
+function assertBodyOverridesBeforePromptCaching(functionNeedle) {
+    const functionStart = serviceSource.indexOf(functionNeedle);
+    assert.ok(functionStart >= 0, `${functionNeedle} should exist`);
+
+    const bodyOverrideIndex = serviceSource.indexOf(
+        'additional_parameters.apply_body_overrides(&mut upstream_payload)?;',
+        functionStart,
+    );
+    const promptCachingIndex = serviceSource.indexOf(
+        'self.apply_tauritavern_prompt_caching(',
+        functionStart,
+    );
+
+    assert.ok(bodyOverrideIndex >= 0, `${functionNeedle} should apply body overrides`);
+    assert.ok(promptCachingIndex >= 0, `${functionNeedle} should apply prompt caching`);
+    assert.ok(
+        bodyOverrideIndex < promptCachingIndex,
+        `${functionNeedle} must apply custom body overrides before prompt caching`,
+    );
+}
+
+test('chat generation applies final body overrides before prompt caching', () => {
+    assertBodyOverridesBeforePromptCaching('async fn execute_generate(');
+});
+
+test('stream generation applies final body overrides before prompt caching', () => {
+    assertBodyOverridesBeforePromptCaching('pub async fn generate_stream(');
+});


### PR DESCRIPTION
## 修改内容

将自定义 body overrides 的应用时机提前到 TauriTavern prompt caching 之前，覆盖普通生成和流式生成两条路径。

这样可以确保自定义 Claude cache/body 参数先进入 upstream payload，再由 prompt caching 逻辑处理，实测可以提高缓存命中率。

## 具体改动

- 将 `additional_parameters.apply_body_overrides(...)` 移到 `apply_tauritavern_prompt_caching(...)` 之前
- 普通生成和流式生成路径保持一致
- 新增 contract test，避免后续调用顺序被改回导致回归

## 测试

- `pnpm run test:contracts`