### PR TITLE
Include user cache in default sync scope

### DIFF
--- a/src-tauri/src/domain/models/sync_automation.rs
+++ b/src-tauri/src/domain/models/sync_automation.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use ttsync_contract::dataset::DatasetSelection;
-use ttsync_core::dataset::tauri_tavern_default_selection;
 
 pub const SYNC_AUTOMATION_COLD_START_DELAY_SECS: u64 = 45;
 pub const SYNC_AUTOMATION_MIN_INTERVAL_MINUTES: u16 = 5;
 pub const SYNC_AUTOMATION_MAX_INTERVAL_MINUTES: u16 = 1440;
+const LEGACY_USER_DATASET_ID: &str = "legacy.user";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -23,7 +23,7 @@ pub struct SyncAutomationConfig {
     pub interval_minutes: u16,
     #[serde(default)]
     pub target: Option<SyncAutomationTarget>,
-    #[serde(default = "tauri_tavern_default_selection")]
+    #[serde(default = "tauri_tavern_continuity_selection")]
     pub selection: DatasetSelection,
 }
 
@@ -34,9 +34,21 @@ impl Default for SyncAutomationConfig {
             auto_sync_enabled: false,
             interval_minutes: default_interval_minutes(),
             target: None,
-            selection: tauri_tavern_default_selection(),
+            selection: tauri_tavern_continuity_selection(),
         }
     }
+}
+
+pub fn tauri_tavern_continuity_selection() -> DatasetSelection {
+    let mut selection = ttsync_core::dataset::tauri_tavern_default_selection();
+    if !selection
+        .dataset_ids
+        .iter()
+        .any(|id| id == LEGACY_USER_DATASET_ID)
+    {
+        selection.dataset_ids.push(LEGACY_USER_DATASET_ID.to_string());
+    }
+    selection
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -67,4 +79,27 @@ pub struct SyncAutomationToastEvent {
 
 fn default_interval_minutes() -> u16 {
     30
+}
+
+#[cfg(test)]
+mod tests {
+    use ttsync_core::dataset::ResolvedDatasetPolicy;
+
+    use super::SyncAutomationConfig;
+
+    #[test]
+    fn default_config_includes_user_cache_without_sync_state() {
+        let config = SyncAutomationConfig::default();
+        let policy = ResolvedDatasetPolicy::from_selection(&config.selection)
+            .expect("default automation selection should be valid");
+
+        assert!(
+            policy.contains_path("default-user/user/cache/chat_summary_index_v1.json"),
+            "chat summary indexes are required for automated continuity sync"
+        );
+        assert!(
+            !policy.contains_path("default-user/user/lan-sync/v2/identity.json"),
+            "local sync identities must stay device-local"
+        );
+    }
 }

--- a/src-tauri/src/infrastructure/sync_v2.rs
+++ b/src-tauri/src/infrastructure/sync_v2.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
 use ttsync_contract::dataset::DatasetSelection;
 use ttsync_contract::status::StatusResponse;
-use ttsync_core::dataset::{ResolvedDatasetPolicy, tauri_tavern_default_selection};
+use ttsync_core::dataset::ResolvedDatasetPolicy;
 
 use crate::domain::errors::DomainError;
+use crate::domain::models::sync_automation::tauri_tavern_continuity_selection;
 use crate::infrastructure::sync_bundle::{FEATURE_BUNDLE_V1, FEATURE_ZSTD_V1};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncV2OperationOptions {
-    #[serde(default = "tauri_tavern_default_selection")]
+    #[serde(default = "tauri_tavern_continuity_selection")]
     pub selection: DatasetSelection,
     #[serde(default)]
     pub require_bundle_zstd: bool,
@@ -17,7 +18,7 @@ pub struct SyncV2OperationOptions {
 impl Default for SyncV2OperationOptions {
     fn default() -> Self {
         Self {
-            selection: tauri_tavern_default_selection(),
+            selection: tauri_tavern_continuity_selection(),
             require_bundle_zstd: false,
         }
     }
@@ -66,4 +67,27 @@ pub fn bundle_transport_for_status(
         prefer_bundle: has_bundle,
         use_zstd: has_bundle && has_zstd,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ttsync_core::dataset::ResolvedDatasetPolicy;
+
+    use super::SyncV2OperationOptions;
+
+    #[test]
+    fn default_options_include_user_cache_without_sync_state() {
+        let options = SyncV2OperationOptions::default();
+        let policy = ResolvedDatasetPolicy::from_selection(&options.selection)
+            .expect("default sync selection should be valid");
+
+        assert!(
+            policy.contains_path("default-user/user/cache/chat_summary_index_v1.json"),
+            "chat summary indexes are required to continue synced chats with the same memory"
+        );
+        assert!(
+            !policy.contains_path("default-user/user/lan-sync/v2/identity.json"),
+            "local sync identities must stay device-local"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Include the legacy user dataset in TauriTavern's default v2 sync selection so `default-user/user/cache` is synced by default.
- Keep `default-user/user/lan-sync` excluded through the existing ttsync dataset policy so device-local sync identities and state are not copied.
- Reuse the same continuity default for manual v2 sync options and auto-sync config defaults.

## Root cause
The local data inspection showed active chat continuity data under `default-user/user/cache/chat_summary_index_v1.json`. The v2 default dataset selection included prompt context and several TauriTavern-specific datasets, but did not include the legacy user directory. As a result, receiving devices could continue a synced chat without the matching summary index/cache, which can make memory/context selection diverge after sync.

## Tests
- `cargo test default_options_include_user_cache_without_sync_state --manifest-path .\src-tauri\Cargo.toml`
- `cargo test default_config_includes_user_cache_without_sync_state --manifest-path .\src-tauri\Cargo.toml`
- `cargo test scan_manifest_respects_v2_scope_and_excludes_lan_sync_state --manifest-path .\src-tauri\Cargo.toml`

Additional check:
- `cargo test --lib --manifest-path .\src-tauri\Cargo.toml` reached 1123 passed / 1 failed. The remaining failure is `infrastructure::paths::tests::copy_dir_recursive_preserves_symlinks`, which fails on this Windows host because creating the test symlink requires privilege (`os error 1314`).

Formatting note:
- `cargo fmt --manifest-path .\src-tauri\Cargo.toml` could not run because `cargo-fmt.exe` is not installed for the local stable MSVC toolchain.