### PR TITLE
fix: short description

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+const app = new TauriTavern();
+app.on('notification', (event) => {
+  if (event.type === 'click' && event.data.message === '點擊返回 TauriTavern') {
+    // Move to top of window after click
+    app.window.moveToTop();
+  }
+});


### PR DESCRIPTION
## Fix for #100

The issue is about Windows and Android platform notifications being displayed incorrectly when generated with TauriTavern. Specifically, the '點擊返回 TauriTavern' notification is shown but does not move to the top of the window after a user clicks on it.

### Changes:
- modify: `src/index.js` - The notification is generated with the correct type and event listener, but the window does not move to the top after a user clicks on it.
- modify: `src/index.js` - The notification is generated with the correct type and event listener, but the window does not move to the top after a user clicks on it. The second implementation also has an additional check for the message '點擊返回 TauriTavern' which may cause issues if other notifications have the same type.