### PR TITLE
fix(ui): 修复移动端主题下聊天输入框宽度异常

### DIFF
--- a/src/scripts/chat-input-fullscreen-editor.js
+++ b/src/scripts/chat-input-fullscreen-editor.js
@@ -52,18 +52,23 @@ function createExpandButton(title) {
     return button;
 }
 
-function createInputShell(sourceTextarea) {
+function requireInputHost(sourceTextarea) {
     const nonQRFormItems = requireElement('nonQRFormItems', HTMLElement);
     if (sourceTextarea.parentElement !== nonQRFormItems) {
         throw new Error('Expected #send_textarea to be a direct child of #nonQRFormItems');
     }
 
-    const shell = document.createElement('div');
-    shell.className = 'tt-chat-input-shell';
-    sourceTextarea.before(shell);
-    shell.appendChild(sourceTextarea);
+    return nonQRFormItems;
+}
 
-    return shell;
+function positionExpandButton(button, textarea, inputHost) {
+    const textareaRect = textarea.getBoundingClientRect();
+    const inputHostRect = inputHost.getBoundingClientRect();
+    const topOffset = Math.max(textareaRect.top - inputHostRect.top, 0);
+    const rightOffset = Math.max(inputHostRect.right - textareaRect.right, 0);
+
+    button.style.setProperty('--tt-chat-input-expand-top-offset', `${topOffset}px`);
+    button.style.setProperty('--tt-chat-input-expand-right-offset', `${rightOffset}px`);
 }
 
 function getTextareaContentMetrics(textarea) {
@@ -152,13 +157,13 @@ export function installChatInputFullscreenEditor({ sendTextArea, sendMessage, is
         throw new Error('isMobile must be a function');
     }
 
-    const inputShell = createInputShell(sendTextArea);
+    const inputHost = requireInputHost(sendTextArea);
     const expandButton = createExpandButton('Expand the editor');
     expandButton.id = EXPAND_BUTTON_ID;
     expandButton.hidden = true;
     expandButton.setAttribute('aria-controls', EDITOR_DIALOG_ID);
     expandButton.setAttribute('aria-haspopup', 'dialog');
-    inputShell.appendChild(expandButton);
+    inputHost.appendChild(expandButton);
 
     const { dialog, textarea, collapseButton, sendButton } = createEditorDialog(sendTextArea);
 
@@ -168,7 +173,10 @@ export function installChatInputFullscreenEditor({ sendTextArea, sendMessage, is
 
     const setExpandButtonVisible = (visible) => {
         expandButton.hidden = !visible;
-        inputShell.classList.toggle('tt-chat-input-shell--has-expand', visible);
+        sendTextArea.classList.toggle('tt-chat-input--has-expand', visible);
+        if (visible) {
+            positionExpandButton(expandButton, sendTextArea, inputHost);
+        }
     };
 
     const queueButtonVisibilityUpdate = () => {
@@ -274,6 +282,11 @@ export function installChatInputFullscreenEditor({ sendTextArea, sendMessage, is
 
     sendTextArea.addEventListener('input', queueButtonVisibilityUpdate);
     window.addEventListener('resize', queueButtonVisibilityUpdate);
+    const inputResizeObserver = typeof ResizeObserver === 'function'
+        ? new ResizeObserver(queueButtonVisibilityUpdate)
+        : null;
+    inputResizeObserver?.observe(sendTextArea);
+    inputResizeObserver?.observe(inputHost);
     queueButtonVisibilityUpdate();
 
     return {

--- a/src/style.css
+++ b/src/style.css
@@ -1619,6 +1619,7 @@ button {
     flex: 1;
     min-width: 0;
     order: 3;
+    grid-area: textarea;
 }
 
 .tt-chat-input-shell #send_textarea {

--- a/src/style.css
+++ b/src/style.css
@@ -1609,33 +1609,20 @@ button {
     outline: 1px solid var(--interactable-outline-color-faint);
 }
 
-.tt-chat-input-shell {
+#nonQRFormItems {
     --tt-chat-input-expand-hit-size: clamp(20px, calc(var(--bottomFormIconSize) * 0.68), 24px);
     --tt-chat-input-expand-mark-size: clamp(11px, calc(var(--bottomFormIconSize) * 0.42), 14px);
     --tt-chat-input-expand-stroke: clamp(1.5px, calc(var(--mainFontSize) * 0.11), 2px);
-
-    position: relative;
-    display: flex;
-    flex: 1;
-    min-width: 0;
-    order: 3;
-    grid-area: textarea;
 }
 
-.tt-chat-input-shell #send_textarea {
-    flex: 1 1 auto;
-    width: 100%;
-    min-width: 0;
-}
-
-.tt-chat-input-shell--has-expand #send_textarea {
+#send_textarea.tt-chat-input--has-expand {
     padding-right: calc(var(--tt-chat-input-expand-hit-size) + 5px);
 }
 
 .tt-chat-input-expand-corner {
     position: absolute;
-    top: max(4px, calc(var(--progWidth, 3px) + 3px));
-    right: 6px;
+    top: calc(var(--tt-chat-input-expand-top-offset, 0px) + max(4px, calc(var(--progWidth, 3px) + 3px)));
+    right: calc(var(--tt-chat-input-expand-right-offset, 0px) + 6px);
     width: var(--tt-chat-input-expand-hit-size);
     height: var(--tt-chat-input-expand-hit-size);
     margin: 0;

--- a/tests/chat-input-theme-compat-contract.test.mjs
+++ b/tests/chat-input-theme-compat-contract.test.mjs
@@ -6,10 +6,15 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-test('chat input shell preserves the textarea named grid area used by mobile themes', async () => {
-    const source = await readFile(path.join(REPO_ROOT, 'src/style.css'), 'utf8');
-    const shellRule = source.match(/\.tt-chat-input-shell\s*\{([\s\S]*?)\n\}/);
+test('chat input overlay preserves the textarea as a direct theme layout item', async () => {
+    const [scriptSource, styleSource] = await Promise.all([
+        readFile(path.join(REPO_ROOT, 'src/scripts/chat-input-fullscreen-editor.js'), 'utf8'),
+        readFile(path.join(REPO_ROOT, 'src/style.css'), 'utf8'),
+    ]);
 
-    assert.ok(shellRule, 'chat input shell CSS rule not found');
-    assert.match(shellRule[1], /grid-area:\s*textarea\s*;/);
+    assert.doesNotMatch(scriptSource, /appendChild\(sourceTextarea\)|sourceTextarea\.before\(/);
+    assert.match(scriptSource, /inputHost\.appendChild\(expandButton\)/);
+    assert.match(scriptSource, /getBoundingClientRect\(\)/);
+    assert.doesNotMatch(styleSource, /\.tt-chat-input-shell/);
+    assert.doesNotMatch(styleSource, /\.tt-chat-input[^\{]*\{[^}]*grid-area:\s*textarea\s*;/s);
 });

--- a/tests/chat-input-theme-compat-contract.test.mjs
+++ b/tests/chat-input-theme-compat-contract.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('chat input shell preserves the textarea named grid area used by mobile themes', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/style.css'), 'utf8');
+    const shellRule = source.match(/\.tt-chat-input-shell\s*\{([\s\S]*?)\n\}/);
+
+    assert.ok(shellRule, 'chat input shell CSS rule not found');
+    assert.match(shellRule[1], /grid-area:\s*textarea\s*;/);
+});


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

## 变更说明 / Summary

问题：
Android 使用 `SillyTavern-MoonlitEchoesTheme` 等基于 Grid 布局的主题时，聊天输入框只能使用约一半宽度，文字提前换行，右侧出现大片空白。

原因：
TauriTavern 的 `.tt-chat-input-shell` 没有保留上游主题使用的 `textarea` 命名网格区域。
当第三方主题将发送栏切换为 Grid 布局时，输入框无法匹配 `textarea` 区域，导致布局计算异常。

变更：
为 `.tt-chat-input-shell` 增加：
```css
grid-area: textarea;
```
## Vibe Coding / AI 辅助 / AI Assistance

使用了codex辅助编程，使用adb调试抓取程序日志，手动编译apk和exe并人工测试该PR的更改已生效且没有副作用，没有破坏性更改