### PR TITLE
perf: world info tokenization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7484,6 +7484,7 @@ dependencies = [
  "flate2",
  "miktik",
  "serde_json",
+ "tiktoken-rs",
  "tokio",
  "tt-adapter-http",
  "tt-domain",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3886,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "miktik"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f2404d749ecc2e98aa1a7f3f01104f26bb39b4d1bb499fedcc57dd8967a889"
+checksum = "6c50c206755571b6deb043b8465430cc14cf630b73c65fc5cb631aece1e28033"
 dependencies = [
  "sentencepiece-model",
  "thiserror 2.0.18",
@@ -7484,7 +7484,6 @@ dependencies = [
  "flate2",
  "miktik",
  "serde_json",
- "tiktoken-rs",
  "tokio",
  "tt-adapter-http",
  "tt-domain",

--- a/src-tauri/crates/tauritavern/src/presentation/commands/registry.rs
+++ b/src-tauri/crates/tauritavern/src/presentation/commands/registry.rs
@@ -346,6 +346,7 @@ pub fn invoke_handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Sen
         // Tokenizer commands
         super::tokenizer_commands::count_openai_tokens,
         super::tokenizer_commands::count_openai_tokens_batch,
+        super::tokenizer_commands::count_openai_token_prefixes,
         super::tokenizer_commands::encode_openai_tokens,
         super::tokenizer_commands::decode_openai_tokens,
         super::tokenizer_commands::build_openai_logit_bias,

--- a/src-tauri/crates/tauritavern/src/presentation/commands/tokenizer_commands.rs
+++ b/src-tauri/crates/tauritavern/src/presentation/commands/tokenizer_commands.rs
@@ -9,7 +9,7 @@ use tt_application::dto::tokenization_dto::{
     OpenAiDecodeRequestDto, OpenAiDecodeResponseDto, OpenAiEncodeRequestDto,
     OpenAiEncodeResponseDto, OpenAiLogitBiasRequestDto, OpenAiLogitBiasResponseDto,
     OpenAiTokenCountBatchRequestDto, OpenAiTokenCountBatchResponseDto, OpenAiTokenCountRequestDto,
-    OpenAiTokenCountResponseDto,
+    OpenAiTokenCountResponseDto, OpenAiTokenPrefixCountRequestDto,
 };
 
 #[tauri::command]
@@ -40,6 +40,21 @@ pub async fn count_openai_tokens_batch(
         .count_openai_tokens_batch(dto)
         .await
         .map_err(map_command_error("Failed to count OpenAI tokens batch"))
+}
+
+#[tauri::command]
+pub async fn count_openai_token_prefixes(
+    dto: OpenAiTokenPrefixCountRequestDto,
+    app_state: State<'_, Arc<AppState>>,
+) -> Result<OpenAiTokenCountBatchResponseDto, CommandError> {
+    log_command("count_openai_token_prefixes");
+
+    app_state
+        .services
+        .tokenization_service
+        .count_openai_token_prefixes(dto)
+        .await
+        .map_err(map_command_error("Failed to count OpenAI token prefixes"))
 }
 
 #[tauri::command]

--- a/src-tauri/crates/tt-adapter-tokenization/Cargo.toml
+++ b/src-tauri/crates/tt-adapter-tokenization/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1"
 flate2 = "1.1.9"
 miktik = { version = "0.2.0", default-features = false, features = ["openai", "huggingface", "sentencepiece"] }
 serde_json = { workspace = true }
+tiktoken-rs = "0.9.1"
 tokio = { version = "1", default-features = false, features = ["fs", "rt", "sync"] }
 tt-adapter-http = { path = "../tt-adapter-http" }
 tt-domain = { path = "../tt-domain" }

--- a/src-tauri/crates/tt-adapter-tokenization/Cargo.toml
+++ b/src-tauri/crates/tt-adapter-tokenization/Cargo.toml
@@ -7,9 +7,8 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 flate2 = "1.1.9"
-miktik = { version = "0.2.0", default-features = false, features = ["openai", "huggingface", "sentencepiece"] }
+miktik = { version = "0.3.0", default-features = false, features = ["openai", "huggingface", "sentencepiece"] }
 serde_json = { workspace = true }
-tiktoken-rs = "0.9.1"
 tokio = { version = "1", default-features = false, features = ["fs", "rt", "sync"] }
 tt-adapter-http = { path = "../tt-adapter-http" }
 tt-domain = { path = "../tt-domain" }

--- a/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
+++ b/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
@@ -1,21 +1,20 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock as StdRwLock};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use flate2::read::GzDecoder;
 use miktik::{TokenizerError, TokenizerRegistry};
 use serde_json::Value;
-use tiktoken_rs::{CoreBPE, get_bpe_from_model};
 use tokio::sync::{Mutex, RwLock};
 
 use tt_adapter_http::{HttpClientPool, HttpClientProfile};
 use tt_domain::errors::DomainError;
 use tt_ports::repositories::tokenizer_repository::{
-    TokenizerRepository, count_system_message_prefixes_default, has_reached_openai_text_token_limit,
+    TokenizerRepository, has_reached_openai_text_token_limit, openai_text_token_count,
 };
 
 const CLAUDE_JSON_GZIP_BYTES: &[u8] =
@@ -24,6 +23,7 @@ const DEEPSEEK_JSON_GZIP_BYTES: &[u8] =
     include_bytes!("../../../resources/tokenizers/deepseek.json.gz");
 const GEMMA_MODEL_GZIP_BYTES: &[u8] =
     include_bytes!("../../../resources/tokenizers/gemma.model.gz");
+const PREFIX_EXACT_REFINEMENT_MARGIN: usize = 64;
 
 #[derive(Clone, Copy)]
 enum ResourceCompression {
@@ -53,7 +53,6 @@ pub struct MiktikTokenizerRepository {
     registry: Arc<TokenizerRegistry>,
     cache_dir: PathBuf,
     http_clients: Arc<HttpClientPool>,
-    openai_tokenizers: Arc<StdRwLock<HashMap<&'static str, Arc<CoreBPE>>>>,
     ready_models: RwLock<HashSet<&'static str>>,
     registration_guard: Mutex<()>,
 }
@@ -64,7 +63,6 @@ impl MiktikTokenizerRepository {
             registry: Arc::new(TokenizerRegistry::new()),
             cache_dir,
             http_clients,
-            openai_tokenizers: Arc::new(StdRwLock::new(HashMap::new())),
             ready_models: RwLock::new(HashSet::new()),
             registration_guard: Mutex::new(()),
         }
@@ -179,21 +177,6 @@ impl MiktikTokenizerRepository {
             return Ok(());
         }
 
-        if TokenizerRegistry::is_tiktoken_model(canonical) {
-            let tokenizers = Arc::clone(&self.openai_tokenizers);
-            tokio::task::spawn_blocking(move || {
-                Self::get_or_load_openai_tokenizer(&tokenizers, canonical)
-            })
-            .await
-            .map_err(|error| {
-                DomainError::InternalError(format!(
-                    "OpenAI tokenizer warm-up task failed for '{canonical}': {error}"
-                ))
-            })??;
-            self.mark_model_ready(canonical).await;
-            return Ok(());
-        }
-
         if !TokenizerRegistry::is_huggingface_model(canonical) {
             self.warm_model(canonical).await?;
             self.mark_model_ready(canonical).await;
@@ -218,49 +201,6 @@ impl MiktikTokenizerRepository {
 
         self.mark_model_ready(canonical).await;
         Ok(())
-    }
-
-    fn get_openai_tokenizer(&self, canonical: &'static str) -> Result<Arc<CoreBPE>, DomainError> {
-        Self::get_or_load_openai_tokenizer(&self.openai_tokenizers, canonical)
-    }
-
-    fn get_or_load_openai_tokenizer(
-        tokenizers: &StdRwLock<HashMap<&'static str, Arc<CoreBPE>>>,
-        canonical: &'static str,
-    ) -> Result<Arc<CoreBPE>, DomainError> {
-        if let Some(tokenizer) = tokenizers
-            .read()
-            .map_err(|error| {
-                DomainError::InternalError(format!(
-                    "OpenAI tokenizer cache read lock failed for '{canonical}': {error}"
-                ))
-            })?
-            .get(canonical)
-        {
-            return Ok(Arc::clone(tokenizer));
-        }
-
-        let mut tokenizers = tokenizers.write().map_err(|error| {
-            DomainError::InternalError(format!(
-                "OpenAI tokenizer cache write lock failed for '{canonical}': {error}"
-            ))
-        })?;
-        if let Some(tokenizer) = tokenizers.get(canonical) {
-            return Ok(Arc::clone(tokenizer));
-        }
-
-        let runtime_model = if canonical == "o1" {
-            "gpt-4o"
-        } else {
-            canonical
-        };
-        let tokenizer = Arc::new(get_bpe_from_model(runtime_model).map_err(|error| {
-            DomainError::InternalError(format!(
-                "Failed to load OpenAI tokenizer '{runtime_model}' for '{canonical}': {error}"
-            ))
-        })?);
-        tokenizers.insert(canonical, Arc::clone(&tokenizer));
-        Ok(tokenizer)
     }
 
     fn register_model_file(
@@ -597,7 +537,10 @@ impl MiktikTokenizerRepository {
         let is_legacy = canonical == "gpt-3.5-turbo-0301";
         let tokens_per_message = if is_legacy { 4_i32 } else { 3_i32 };
         let tokens_per_name = if is_legacy { -1_i32 } else { 1_i32 };
-        let tokenizer = self.get_openai_tokenizer(canonical)?;
+        let tokenizer = self
+            .registry
+            .get_canonical(canonical)
+            .map_err(|error| Self::map_tokenizer_error("load tokenizer", canonical, error))?;
         let mut total = 0_i32;
 
         for message in messages {
@@ -607,7 +550,9 @@ impl MiktikTokenizerRepository {
                 Value::Object(map) => {
                     for (key, value) in map {
                         let text = Self::value_to_text(value);
-                        let count = tokenizer.encode_ordinary(text.as_ref()).len();
+                        let count = tokenizer.count_tokens(text.as_ref()).map_err(|error| {
+                            Self::map_tokenizer_error("count tokens", canonical, error)
+                        })?;
                         total += count as i32;
                         if key == "name" {
                             total += tokens_per_name;
@@ -616,7 +561,9 @@ impl MiktikTokenizerRepository {
                 }
                 _ => {
                     let text = Self::value_to_text(message);
-                    let count = tokenizer.encode_ordinary(text.as_ref()).len();
+                    let count = tokenizer.count_tokens(text.as_ref()).map_err(|error| {
+                        Self::map_tokenizer_error("count tokens", canonical, error)
+                    })?;
                     total += count as i32;
                 }
             }
@@ -629,105 +576,6 @@ impl MiktikTokenizerRepository {
 
         Ok(total.max(0) as usize)
     }
-
-    fn count_openai_system_message_prefixes(
-        &self,
-        canonical: &'static str,
-        base: &str,
-        suffixes: &[String],
-        stop_at: Option<usize>,
-    ) -> Result<Vec<usize>, DomainError> {
-        let is_legacy = canonical == "gpt-3.5-turbo-0301";
-        let tokenizer = self.get_openai_tokenizer(canonical)?;
-        let role_tokens = tokenizer.encode_ordinary("system").len() as i32;
-        let fixed_tokens = if is_legacy {
-            4 + role_tokens + 3 + 9
-        } else {
-            3 + role_tokens + 3
-        };
-
-        let (_, mut stable_tokens, stable_bytes) =
-            Self::openai_prefix_state(&tokenizer, base, canonical)?;
-        let mut unstable = base[stable_bytes..].to_string();
-
-        let mut token_counts = Vec::with_capacity(suffixes.len());
-        for suffix in suffixes {
-            unstable.push_str(suffix);
-            let (unstable_tokens, new_stable_tokens, new_stable_bytes) =
-                Self::openai_prefix_state(&tokenizer, &unstable, canonical)?;
-            let content_tokens = stable_tokens.saturating_add(unstable_tokens) as i32;
-            let token_count = fixed_tokens.saturating_add(content_tokens).max(0) as usize;
-            token_counts.push(token_count);
-
-            if has_reached_openai_text_token_limit(token_count, stop_at) {
-                token_counts.resize(suffixes.len(), token_count);
-                break;
-            }
-
-            stable_tokens = stable_tokens.saturating_add(new_stable_tokens);
-            if new_stable_bytes > 0 {
-                unstable = unstable[new_stable_bytes..].to_string();
-            }
-        }
-
-        Ok(token_counts)
-    }
-
-    fn openai_prefix_state(
-        tokenizer: &CoreBPE,
-        text: &str,
-        canonical: &str,
-    ) -> Result<(usize, usize, usize), DomainError> {
-        let (tokens, mut unstable_token_count) = tokenizer.encode(text, &HashSet::new());
-        let total_token_count = tokens.len();
-        if unstable_token_count == 0 {
-            return Ok((total_token_count, total_token_count, text.len()));
-        }
-
-        let token_is_all_space = |token| -> Result<bool, DomainError> {
-            let bytes = tokenizer
-                ._decode_native_and_split(vec![token])
-                .next()
-                .ok_or_else(|| {
-                    DomainError::InternalError(format!(
-                        "OpenAI tokenizer boundary was empty for '{canonical}'"
-                    ))
-                })?;
-            Ok(bytes
-                .iter()
-                .rev()
-                .all(|byte| matches!(byte, b' ' | b'\n' | b'\t')))
-        };
-
-        let first_unstable = tokens.len().saturating_sub(unstable_token_count);
-        if token_is_all_space(tokens[first_unstable])? {
-            while unstable_token_count < tokens.len()
-                && token_is_all_space(tokens[tokens.len() - unstable_token_count - 1])?
-            {
-                unstable_token_count += 1;
-            }
-        }
-
-        let mut stable_token_count = tokens.len().saturating_sub(unstable_token_count);
-        let decode_prefix = |count: usize| {
-            tokenizer
-                ._decode_native_and_split(tokens[..count].to_vec())
-                .flatten()
-                .collect::<Vec<_>>()
-        };
-        let mut stable_bytes = decode_prefix(stable_token_count);
-        while stable_token_count > 0 && !text.is_char_boundary(stable_bytes.len()) {
-            stable_token_count -= 1;
-            stable_bytes = decode_prefix(stable_token_count);
-        }
-        if !text.as_bytes().starts_with(&stable_bytes) {
-            return Err(DomainError::InternalError(format!(
-                "OpenAI tokenizer boundary did not match input for '{canonical}'"
-            )));
-        }
-
-        Ok((total_token_count, stable_token_count, stable_bytes.len()))
-    }
 }
 
 #[async_trait::async_trait]
@@ -739,9 +587,6 @@ impl TokenizerRepository for MiktikTokenizerRepository {
 
     fn encode(&self, model: &str, text: &str) -> Result<Vec<u32>, DomainError> {
         let canonical = Self::canonical_model(model);
-        if TokenizerRegistry::is_tiktoken_model(canonical) {
-            return Ok(self.get_openai_tokenizer(canonical)?.encode_ordinary(text));
-        }
         let tokenizer = self
             .registry
             .get_canonical(canonical)
@@ -754,16 +599,6 @@ impl TokenizerRepository for MiktikTokenizerRepository {
 
     fn decode(&self, model: &str, token_ids: &[u32]) -> Result<String, DomainError> {
         let canonical = Self::canonical_model(model);
-        if TokenizerRegistry::is_tiktoken_model(canonical) {
-            return self
-                .get_openai_tokenizer(canonical)?
-                .decode(token_ids.to_vec())
-                .map_err(|error| {
-                    DomainError::InternalError(format!(
-                        "Failed to decode token ids for '{canonical}': {error}"
-                    ))
-                });
-        }
         let tokenizer = self
             .registry
             .get_canonical(canonical)
@@ -807,13 +642,118 @@ impl TokenizerRepository for MiktikTokenizerRepository {
         suffixes: &[String],
         stop_at: Option<usize>,
     ) -> Result<Vec<usize>, DomainError> {
-        let canonical = Self::canonical_model(model);
-
-        if !TokenizerRegistry::is_tiktoken_model(canonical) {
-            return count_system_message_prefixes_default(self, model, base, suffixes, stop_at);
+        if suffixes.is_empty() {
+            return Ok(Vec::new());
         }
 
-        self.count_openai_system_message_prefixes(canonical, base, suffixes, stop_at)
+        let canonical = Self::canonical_model(model);
+        let additions = suffixes.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let mut token_counts = self
+            .registry
+            .estimate_cumulative_token_counts_canonical(canonical, base, &additions)
+            .map_err(|error| {
+                Self::map_tokenizer_error("estimate cumulative token counts", canonical, error)
+            })?;
+        if token_counts.len() != suffixes.len() {
+            return Err(DomainError::InternalError(format!(
+                "cumulative token estimate returned {} counts for {} suffixes on '{canonical}'",
+                token_counts.len(),
+                suffixes.len()
+            )));
+        }
+
+        // Calibrate the estimate against the first real system message so backend-specific
+        // wrapper boundaries remain aligned with the existing count_messages contract.
+        let first_prefix = format!("{base}{}", suffixes[0]);
+        let first_message_count = TokenizerRepository::count_messages(
+            self,
+            canonical,
+            &[serde_json::json!({
+                "role": "system",
+                "content": first_prefix,
+            })],
+        )?;
+        let first_estimate = token_counts[0];
+        let estimate_offset = i128::try_from(first_message_count)
+            .and_then(|message_count| {
+                i128::try_from(first_estimate).map(|estimate| message_count - estimate)
+            })
+            .map_err(|_| {
+                DomainError::InternalError(format!(
+                    "cumulative token estimate exceeded the supported range for '{canonical}'"
+                ))
+            })?;
+
+        for count in &mut token_counts {
+            let adjusted = i128::try_from(*count)
+                .ok()
+                .and_then(|value| value.checked_add(estimate_offset))
+                .and_then(|value| usize::try_from(value).ok())
+                .ok_or_else(|| {
+                    DomainError::InternalError(format!(
+                        "cumulative token estimate overflowed for '{canonical}'"
+                    ))
+                })?;
+            *count = adjusted;
+        }
+
+        let Some(stop_at) = stop_at else {
+            return Ok(token_counts);
+        };
+
+        let content_capacity = suffixes.iter().fold(base.len(), |total, suffix| {
+            total.saturating_add(suffix.len())
+        });
+        let refinement_floor = stop_at.saturating_sub(PREFIX_EXACT_REFINEMENT_MARGIN);
+        let mut refinement_start = token_counts
+            .iter()
+            .position(|&count| openai_text_token_count(count) >= refinement_floor);
+
+        if refinement_start.is_none() {
+            let mut final_content = String::with_capacity(content_capacity);
+            final_content.push_str(base);
+            for suffix in suffixes {
+                final_content.push_str(suffix);
+            }
+            let final_count = TokenizerRepository::count_messages(
+                self,
+                canonical,
+                &[serde_json::json!({
+                    "role": "system",
+                    "content": final_content,
+                })],
+            )?;
+            if has_reached_openai_text_token_limit(final_count, Some(stop_at)) {
+                refinement_start = Some(0);
+            }
+        }
+
+        if let Some(refinement_start) = refinement_start {
+            let mut content = String::with_capacity(content_capacity);
+            content.push_str(base);
+            for suffix in &suffixes[..refinement_start] {
+                content.push_str(suffix);
+            }
+            for (index, suffix) in suffixes.iter().enumerate().skip(refinement_start) {
+                content.push_str(suffix);
+                let exact_count = TokenizerRepository::count_messages(
+                    self,
+                    canonical,
+                    &[serde_json::json!({
+                        "role": "system",
+                        "content": content,
+                    })],
+                )?;
+                token_counts[index] = exact_count;
+                if has_reached_openai_text_token_limit(exact_count, Some(stop_at)) {
+                    token_counts[index..].fill(exact_count);
+                    break;
+                }
+            }
+        }
+
+        Ok(token_counts)
     }
 }
 
@@ -1140,49 +1080,24 @@ mod tests {
     }
 
     #[test]
-    fn shared_openai_tokenizer_matches_miktik_registry() {
-        let cache_dir = unique_temp_cache_dir();
-        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
-        let samples = [
-            "plain ASCII text",
-            "世界设定与标点。",
-            "spaces  \n\tand emoji \u{1f642}",
-            "<|not-a-special-token|>",
-        ];
+    fn cumulative_prefix_counts_return_empty_without_loading_a_model() {
+        let repository =
+            MiktikTokenizerRepository::new(unique_temp_cache_dir(), test_http_clients());
 
-        for model in ["gpt-4o", "gpt-4", "gpt-3.5-turbo-0301", "o1"] {
-            let canonical = MiktikTokenizerRepository::canonical_model(model);
-            let shared = repository
-                .get_openai_tokenizer(canonical)
-                .expect("shared OpenAI tokenizer should load");
-            let registry = repository
-                .registry
-                .get_canonical(canonical)
-                .expect("Miktik tokenizer should load");
+        let counts = TokenizerRepository::count_system_message_prefixes(
+            &repository,
+            "missing-model",
+            "ignored",
+            &[],
+            Some(1),
+        )
+        .expect("empty suffixes should not load a tokenizer");
 
-            for sample in samples {
-                let shared_ids = shared.encode_ordinary(sample);
-                let registry_ids = registry
-                    .encode(sample)
-                    .expect("Miktik encode should succeed");
-                assert_eq!(shared_ids, registry_ids, "encoding changed for {model}");
-                assert_eq!(
-                    shared
-                        .decode(shared_ids.clone())
-                        .expect("shared decode should succeed"),
-                    registry
-                        .decode(&registry_ids)
-                        .expect("Miktik decode should succeed"),
-                    "decoding changed for {model}"
-                );
-            }
-        }
-
-        let _ = std::fs::remove_dir_all(cache_dir);
+        assert!(counts.is_empty());
     }
 
-    #[test]
-    fn openai_prefix_counts_match_individual_system_messages() {
+    #[tokio::test]
+    async fn cumulative_prefix_counts_match_individual_messages_across_backends() {
         let cache_dir = unique_temp_cache_dir();
         let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
         let base = "世界设定\n";
@@ -1192,7 +1107,16 @@ mod tests {
             "  whitespace and emoji: \u{1f642}\n".to_string(),
         ];
 
-        for model in ["gpt-4o", "gpt-3.5-turbo-0301"] {
+        for model in [
+            "gpt-4o",
+            "gpt-3.5-turbo-0301",
+            "claude",
+            "deepseek",
+            "gemma",
+        ] {
+            TokenizerRepository::ensure_model_ready(&repository, model)
+                .await
+                .expect("tokenizer should prepare");
             let actual = TokenizerRepository::count_system_message_prefixes(
                 &repository,
                 model,
@@ -1219,8 +1143,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(cache_dir);
     }
 
-    #[test]
-    fn openai_incremental_prefix_counts_match_boundary_corpus() {
+    #[tokio::test]
+    async fn cumulative_prefix_estimates_track_boundary_corpus_across_backends() {
         let cache_dir = unique_temp_cache_dir();
         let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
         let fragments = [
@@ -1238,10 +1162,19 @@ mod tests {
             "<|not-a-special-token|>",
         ];
 
-        for model in ["gpt-4o", "gpt-4", "gpt-3.5-turbo-0301", "o1"] {
+        for model in [
+            "gpt-4o",
+            "gpt-3.5-turbo-0301",
+            "claude",
+            "deepseek",
+            "gemma",
+        ] {
+            TokenizerRepository::ensure_model_ready(&repository, model)
+                .await
+                .expect("tokenizer should prepare");
             for base_index in 0..fragments.len() {
                 let base = fragments[..=base_index].concat();
-                let suffixes = (0..64)
+                let suffixes = (0..32)
                     .map(|index| fragments[(base_index + index + 1) % fragments.len()].to_string())
                     .collect::<Vec<_>>();
                 let actual = TokenizerRepository::count_system_message_prefixes(
@@ -1253,7 +1186,7 @@ mod tests {
                 )
                 .expect("incremental prefix counts should succeed");
 
-                let mut content = base;
+                let mut content = base.clone();
                 let expected = suffixes
                     .iter()
                     .map(|suffix| {
@@ -1267,15 +1200,70 @@ mod tests {
                     })
                     .collect::<Vec<_>>();
 
-                assert_eq!(actual, expected, "prefix counts changed for {model}");
+                if miktik::TokenizerRegistry::is_tiktoken_model(
+                    MiktikTokenizerRepository::canonical_model(model),
+                ) {
+                    assert_eq!(actual, expected, "prefix counts changed for {model}");
+                } else {
+                    for (estimate, exact) in actual.iter().zip(&expected) {
+                        assert!(
+                            estimate.abs_diff(*exact) <= 1,
+                            "prefix estimate drifted for {model}: estimate={estimate}, exact={exact}"
+                        );
+                    }
+                }
+
+                let max_visible_count = expected
+                    .iter()
+                    .copied()
+                    .map(openai_text_token_count)
+                    .max()
+                    .unwrap_or_default();
+                let mismatched_thresholds = (0..=max_visible_count)
+                    .filter(|&stop_at| {
+                        let estimated_index = actual
+                            .iter()
+                            .position(|&count| openai_text_token_count(count) >= stop_at);
+                        let exact_index = expected
+                            .iter()
+                            .position(|&count| openai_text_token_count(count) >= stop_at);
+                        estimated_index != exact_index
+                    })
+                    .collect::<Vec<_>>();
+                for stop_at in mismatched_thresholds
+                    .into_iter()
+                    .chain(std::iter::once(max_visible_count / 2))
+                {
+                    let stopped = TokenizerRepository::count_system_message_prefixes(
+                        &repository,
+                        model,
+                        &base,
+                        &suffixes,
+                        Some(stop_at),
+                    )
+                    .expect("threshold-refined prefix counts should succeed");
+                    let estimated_index = actual
+                        .iter()
+                        .position(|&count| openai_text_token_count(count) >= stop_at);
+                    let exact_index = expected
+                        .iter()
+                        .position(|&count| openai_text_token_count(count) >= stop_at);
+                    let stopped_index = stopped
+                        .iter()
+                        .position(|&count| openai_text_token_count(count) >= stop_at);
+                    assert_eq!(
+                        stopped_index, exact_index,
+                        "prefix threshold refinement failed for {model} at {stop_at}; estimate crossed at {estimated_index:?}"
+                    );
+                }
             }
         }
 
         let _ = std::fs::remove_dir_all(cache_dir);
     }
 
-    #[test]
-    fn openai_prefix_counts_preserve_stop_at_fill_semantics() {
+    #[tokio::test]
+    async fn cumulative_prefix_counts_preserve_stop_at_fill_across_backends() {
         let cache_dir = unique_temp_cache_dir();
         let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
         let suffixes = vec![
@@ -1283,29 +1271,100 @@ mod tests {
             "a considerably longer second entry\n".to_string(),
             "this entry must not need to be tokenized\n".to_string(),
         ];
-        let full_counts = TokenizerRepository::count_system_message_prefixes(
-            &repository,
-            "gpt-4o",
-            "base\n",
-            &suffixes,
-            None,
-        )
-        .expect("full prefix counts should succeed");
-        let stop_at = openai_text_token_count(full_counts[1]);
+        for model in ["gpt-4o", "claude", "deepseek", "gemma"] {
+            TokenizerRepository::ensure_model_ready(&repository, model)
+                .await
+                .expect("tokenizer should prepare");
+            let full_counts = TokenizerRepository::count_system_message_prefixes(
+                &repository,
+                model,
+                "base\n",
+                &suffixes,
+                None,
+            )
+            .expect("full prefix counts should succeed");
+            let stop_at = openai_text_token_count(full_counts[1]);
 
-        let stopped_counts = TokenizerRepository::count_system_message_prefixes(
-            &repository,
-            "gpt-4o",
-            "base\n",
-            &suffixes,
-            Some(stop_at),
-        )
-        .expect("stopped prefix counts should succeed");
+            let stopped_counts = TokenizerRepository::count_system_message_prefixes(
+                &repository,
+                model,
+                "base\n",
+                &suffixes,
+                Some(stop_at),
+            )
+            .expect("stopped prefix counts should succeed");
 
-        assert_eq!(
-            stopped_counts,
-            vec![full_counts[0], full_counts[1], full_counts[1]]
-        );
+            assert_eq!(
+                stopped_counts,
+                vec![full_counts[0], full_counts[1], full_counts[1]],
+                "stop/fill semantics changed for {model}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[tokio::test]
+    async fn cumulative_prefix_counts_preserve_large_world_info_thresholds() {
+        let cache_dir = unique_temp_cache_dir();
+        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
+        let base =
+            "Stable world context with ordinary text, punctuation, and spacing.\n".repeat(120);
+        let suffixes = (0..32)
+            .map(|index| format!("Entry {index}: 世界设定 with details, spaces, and emoji 🙂.\n"))
+            .collect::<Vec<_>>();
+
+        for model in ["gpt-4o", "claude", "deepseek", "gemma"] {
+            TokenizerRepository::ensure_model_ready(&repository, model)
+                .await
+                .expect("tokenizer should prepare");
+
+            let mut content = base.clone();
+            let exact_counts = suffixes
+                .iter()
+                .map(|suffix| {
+                    content.push_str(suffix);
+                    TokenizerRepository::count_messages(
+                        &repository,
+                        model,
+                        &[json!({ "role": "system", "content": content })],
+                    )
+                    .expect("complete prefix count should succeed")
+                })
+                .collect::<Vec<_>>();
+            let stop_at = openai_text_token_count(exact_counts[20]);
+            let expected_index = exact_counts
+                .iter()
+                .position(|&count| openai_text_token_count(count) >= stop_at)
+                .expect("exact counts should reach the selected threshold");
+
+            let stopped_counts = TokenizerRepository::count_system_message_prefixes(
+                &repository,
+                model,
+                &base,
+                &suffixes,
+                Some(stop_at),
+            )
+            .expect("threshold-refined prefix counts should succeed");
+            let stopped_index = stopped_counts
+                .iter()
+                .position(|&count| openai_text_token_count(count) >= stop_at)
+                .expect("refined counts should reach the selected threshold");
+
+            assert_eq!(
+                stopped_index, expected_index,
+                "large world-info threshold crossing changed for {model}"
+            );
+            assert_eq!(
+                stopped_counts[expected_index], exact_counts[expected_index],
+                "large world-info terminal count changed for {model}"
+            );
+            assert!(
+                stopped_counts[expected_index..]
+                    .iter()
+                    .all(|&count| count == exact_counts[expected_index])
+            );
+        }
+
         let _ = std::fs::remove_dir_all(cache_dir);
     }
 }

--- a/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
+++ b/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
@@ -1,19 +1,22 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use flate2::read::GzDecoder;
 use miktik::{TokenizerError, TokenizerRegistry};
 use serde_json::Value;
+use tiktoken_rs::{CoreBPE, get_bpe_from_model};
 use tokio::sync::{Mutex, RwLock};
 
 use tt_adapter_http::{HttpClientPool, HttpClientProfile};
 use tt_domain::errors::DomainError;
-use tt_ports::repositories::tokenizer_repository::TokenizerRepository;
+use tt_ports::repositories::tokenizer_repository::{
+    TokenizerRepository, count_system_message_prefixes_default,
+};
 
 const CLAUDE_JSON_GZIP_BYTES: &[u8] =
     include_bytes!("../../../resources/tokenizers/claude.json.gz");
@@ -50,6 +53,7 @@ pub struct MiktikTokenizerRepository {
     registry: Arc<TokenizerRegistry>,
     cache_dir: PathBuf,
     http_clients: Arc<HttpClientPool>,
+    openai_tokenizers: Arc<StdRwLock<HashMap<&'static str, Arc<CoreBPE>>>>,
     ready_models: RwLock<HashSet<&'static str>>,
     registration_guard: Mutex<()>,
 }
@@ -60,6 +64,7 @@ impl MiktikTokenizerRepository {
             registry: Arc::new(TokenizerRegistry::new()),
             cache_dir,
             http_clients,
+            openai_tokenizers: Arc::new(StdRwLock::new(HashMap::new())),
             ready_models: RwLock::new(HashSet::new()),
             registration_guard: Mutex::new(()),
         }
@@ -174,6 +179,21 @@ impl MiktikTokenizerRepository {
             return Ok(());
         }
 
+        if TokenizerRegistry::is_tiktoken_model(canonical) {
+            let tokenizers = Arc::clone(&self.openai_tokenizers);
+            tokio::task::spawn_blocking(move || {
+                Self::get_or_load_openai_tokenizer(&tokenizers, canonical)
+            })
+            .await
+            .map_err(|error| {
+                DomainError::InternalError(format!(
+                    "OpenAI tokenizer warm-up task failed for '{canonical}': {error}"
+                ))
+            })??;
+            self.mark_model_ready(canonical).await;
+            return Ok(());
+        }
+
         if !TokenizerRegistry::is_huggingface_model(canonical) {
             self.warm_model(canonical).await?;
             self.mark_model_ready(canonical).await;
@@ -198,6 +218,49 @@ impl MiktikTokenizerRepository {
 
         self.mark_model_ready(canonical).await;
         Ok(())
+    }
+
+    fn get_openai_tokenizer(&self, canonical: &'static str) -> Result<Arc<CoreBPE>, DomainError> {
+        Self::get_or_load_openai_tokenizer(&self.openai_tokenizers, canonical)
+    }
+
+    fn get_or_load_openai_tokenizer(
+        tokenizers: &StdRwLock<HashMap<&'static str, Arc<CoreBPE>>>,
+        canonical: &'static str,
+    ) -> Result<Arc<CoreBPE>, DomainError> {
+        if let Some(tokenizer) = tokenizers
+            .read()
+            .map_err(|error| {
+                DomainError::InternalError(format!(
+                    "OpenAI tokenizer cache read lock failed for '{canonical}': {error}"
+                ))
+            })?
+            .get(canonical)
+        {
+            return Ok(Arc::clone(tokenizer));
+        }
+
+        let mut tokenizers = tokenizers.write().map_err(|error| {
+            DomainError::InternalError(format!(
+                "OpenAI tokenizer cache write lock failed for '{canonical}': {error}"
+            ))
+        })?;
+        if let Some(tokenizer) = tokenizers.get(canonical) {
+            return Ok(Arc::clone(tokenizer));
+        }
+
+        let runtime_model = if canonical == "o1" {
+            "gpt-4o"
+        } else {
+            canonical
+        };
+        let tokenizer = Arc::new(get_bpe_from_model(runtime_model).map_err(|error| {
+            DomainError::InternalError(format!(
+                "Failed to load OpenAI tokenizer '{runtime_model}' for '{canonical}': {error}"
+            ))
+        })?);
+        tokenizers.insert(canonical, Arc::clone(&tokenizer));
+        Ok(tokenizer)
     }
 
     fn register_model_file(
@@ -534,10 +597,7 @@ impl MiktikTokenizerRepository {
         let is_legacy = canonical == "gpt-3.5-turbo-0301";
         let tokens_per_message = if is_legacy { 4_i32 } else { 3_i32 };
         let tokens_per_name = if is_legacy { -1_i32 } else { 1_i32 };
-        let tokenizer = self
-            .registry
-            .get_canonical(canonical)
-            .map_err(|error| Self::map_tokenizer_error("load tokenizer", canonical, error))?;
+        let tokenizer = self.get_openai_tokenizer(canonical)?;
         let mut total = 0_i32;
 
         for message in messages {
@@ -547,9 +607,7 @@ impl MiktikTokenizerRepository {
                 Value::Object(map) => {
                     for (key, value) in map {
                         let text = Self::value_to_text(value);
-                        let count = tokenizer.count_tokens(text.as_ref()).map_err(|error| {
-                            Self::map_tokenizer_error("count tokens", canonical, error)
-                        })?;
+                        let count = tokenizer.encode_ordinary(text.as_ref()).len();
                         total += count as i32;
                         if key == "name" {
                             total += tokens_per_name;
@@ -558,9 +616,7 @@ impl MiktikTokenizerRepository {
                 }
                 _ => {
                     let text = Self::value_to_text(message);
-                    let count = tokenizer.count_tokens(text.as_ref()).map_err(|error| {
-                        Self::map_tokenizer_error("count tokens", canonical, error)
-                    })?;
+                    let count = tokenizer.encode_ordinary(text.as_ref()).len();
                     total += count as i32;
                 }
             }
@@ -573,6 +629,105 @@ impl MiktikTokenizerRepository {
 
         Ok(total.max(0) as usize)
     }
+
+    fn count_openai_system_message_prefixes(
+        &self,
+        canonical: &'static str,
+        base: &str,
+        suffixes: &[String],
+        stop_at: Option<usize>,
+    ) -> Result<Vec<usize>, DomainError> {
+        let is_legacy = canonical == "gpt-3.5-turbo-0301";
+        let tokenizer = self.get_openai_tokenizer(canonical)?;
+        let role_tokens = tokenizer.encode_ordinary("system").len() as i32;
+        let fixed_tokens = if is_legacy {
+            4 + role_tokens + 3 + 9
+        } else {
+            3 + role_tokens + 3
+        };
+
+        let (_, mut stable_tokens, stable_bytes) =
+            Self::openai_prefix_state(&tokenizer, base, canonical)?;
+        let mut unstable = base[stable_bytes..].to_string();
+
+        let mut token_counts = Vec::with_capacity(suffixes.len());
+        for suffix in suffixes {
+            unstable.push_str(suffix);
+            let (unstable_tokens, new_stable_tokens, new_stable_bytes) =
+                Self::openai_prefix_state(&tokenizer, &unstable, canonical)?;
+            let content_tokens = stable_tokens.saturating_add(unstable_tokens) as i32;
+            let token_count = fixed_tokens.saturating_add(content_tokens).max(0) as usize;
+            token_counts.push(token_count);
+
+            if stop_at.is_some_and(|limit| token_count.saturating_sub(1) >= limit) {
+                token_counts.resize(suffixes.len(), token_count);
+                break;
+            }
+
+            stable_tokens = stable_tokens.saturating_add(new_stable_tokens);
+            if new_stable_bytes > 0 {
+                unstable = unstable[new_stable_bytes..].to_string();
+            }
+        }
+
+        Ok(token_counts)
+    }
+
+    fn openai_prefix_state(
+        tokenizer: &CoreBPE,
+        text: &str,
+        canonical: &str,
+    ) -> Result<(usize, usize, usize), DomainError> {
+        let (tokens, mut unstable_token_count) = tokenizer.encode(text, &HashSet::new());
+        let total_token_count = tokens.len();
+        if unstable_token_count == 0 {
+            return Ok((total_token_count, total_token_count, text.len()));
+        }
+
+        let token_is_all_space = |token| -> Result<bool, DomainError> {
+            let bytes = tokenizer
+                ._decode_native_and_split(vec![token])
+                .next()
+                .ok_or_else(|| {
+                    DomainError::InternalError(format!(
+                        "OpenAI tokenizer boundary was empty for '{canonical}'"
+                    ))
+                })?;
+            Ok(bytes
+                .iter()
+                .rev()
+                .all(|byte| matches!(byte, b' ' | b'\n' | b'\t')))
+        };
+
+        let first_unstable = tokens.len().saturating_sub(unstable_token_count);
+        if token_is_all_space(tokens[first_unstable])? {
+            while unstable_token_count < tokens.len()
+                && token_is_all_space(tokens[tokens.len() - unstable_token_count - 1])?
+            {
+                unstable_token_count += 1;
+            }
+        }
+
+        let mut stable_token_count = tokens.len().saturating_sub(unstable_token_count);
+        let decode_prefix = |count: usize| {
+            tokenizer
+                ._decode_native_and_split(tokens[..count].to_vec())
+                .flatten()
+                .collect::<Vec<_>>()
+        };
+        let mut stable_bytes = decode_prefix(stable_token_count);
+        while stable_token_count > 0 && !text.is_char_boundary(stable_bytes.len()) {
+            stable_token_count -= 1;
+            stable_bytes = decode_prefix(stable_token_count);
+        }
+        if !text.as_bytes().starts_with(&stable_bytes) {
+            return Err(DomainError::InternalError(format!(
+                "OpenAI tokenizer boundary did not match input for '{canonical}'"
+            )));
+        }
+
+        Ok((total_token_count, stable_token_count, stable_bytes.len()))
+    }
 }
 
 #[async_trait::async_trait]
@@ -584,6 +739,9 @@ impl TokenizerRepository for MiktikTokenizerRepository {
 
     fn encode(&self, model: &str, text: &str) -> Result<Vec<u32>, DomainError> {
         let canonical = Self::canonical_model(model);
+        if TokenizerRegistry::is_tiktoken_model(canonical) {
+            return Ok(self.get_openai_tokenizer(canonical)?.encode_ordinary(text));
+        }
         let tokenizer = self
             .registry
             .get_canonical(canonical)
@@ -596,6 +754,16 @@ impl TokenizerRepository for MiktikTokenizerRepository {
 
     fn decode(&self, model: &str, token_ids: &[u32]) -> Result<String, DomainError> {
         let canonical = Self::canonical_model(model);
+        if TokenizerRegistry::is_tiktoken_model(canonical) {
+            return self
+                .get_openai_tokenizer(canonical)?
+                .decode(token_ids.to_vec())
+                .map_err(|error| {
+                    DomainError::InternalError(format!(
+                        "Failed to decode token ids for '{canonical}': {error}"
+                    ))
+                });
+        }
         let tokenizer = self
             .registry
             .get_canonical(canonical)
@@ -630,6 +798,22 @@ impl TokenizerRepository for MiktikTokenizerRepository {
         }
 
         self.count_openai_messages(canonical, messages)
+    }
+
+    fn count_system_message_prefixes(
+        &self,
+        model: &str,
+        base: &str,
+        suffixes: &[String],
+        stop_at: Option<usize>,
+    ) -> Result<Vec<usize>, DomainError> {
+        let canonical = Self::canonical_model(model);
+
+        if !TokenizerRegistry::is_tiktoken_model(canonical) {
+            return count_system_message_prefixes_default(self, model, base, suffixes, stop_at);
+        }
+
+        self.count_openai_system_message_prefixes(canonical, base, suffixes, stop_at)
     }
 }
 
@@ -951,5 +1135,175 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(cache_dir);
         assert_eq!(legacy, modern + 8);
+    }
+
+    #[test]
+    fn shared_openai_tokenizer_matches_miktik_registry() {
+        let cache_dir = unique_temp_cache_dir();
+        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
+        let samples = [
+            "plain ASCII text",
+            "世界设定与标点。",
+            "spaces  \n\tand emoji \u{1f642}",
+            "<|not-a-special-token|>",
+        ];
+
+        for model in ["gpt-4o", "gpt-4", "gpt-3.5-turbo-0301", "o1"] {
+            let canonical = MiktikTokenizerRepository::canonical_model(model);
+            let shared = repository
+                .get_openai_tokenizer(canonical)
+                .expect("shared OpenAI tokenizer should load");
+            let registry = repository
+                .registry
+                .get_canonical(canonical)
+                .expect("Miktik tokenizer should load");
+
+            for sample in samples {
+                let shared_ids = shared.encode_ordinary(sample);
+                let registry_ids = registry
+                    .encode(sample)
+                    .expect("Miktik encode should succeed");
+                assert_eq!(shared_ids, registry_ids, "encoding changed for {model}");
+                assert_eq!(
+                    shared
+                        .decode(shared_ids.clone())
+                        .expect("shared decode should succeed"),
+                    registry
+                        .decode(&registry_ids)
+                        .expect("Miktik decode should succeed"),
+                    "decoding changed for {model}"
+                );
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[test]
+    fn openai_prefix_counts_match_individual_system_messages() {
+        let cache_dir = unique_temp_cache_dir();
+        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
+        let base = "世界设定\n";
+        let suffixes = vec![
+            "First entry with punctuation!\n".to_string(),
+            "第二条目，包含中文。\n".to_string(),
+            "  whitespace and emoji: \u{1f642}\n".to_string(),
+        ];
+
+        for model in ["gpt-4o", "gpt-3.5-turbo-0301"] {
+            let actual = TokenizerRepository::count_system_message_prefixes(
+                &repository,
+                model,
+                base,
+                &suffixes,
+                None,
+            )
+            .expect("optimized prefix counts should succeed");
+
+            let mut content = base.to_string();
+            let expected = suffixes
+                .iter()
+                .map(|suffix| {
+                    content.push_str(suffix);
+                    let messages = vec![json!({ "role": "system", "content": content })];
+                    TokenizerRepository::count_messages(&repository, model, &messages)
+                        .expect("individual system message count should succeed")
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(actual, expected, "prefix counts changed for {model}");
+        }
+
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[test]
+    fn openai_incremental_prefix_counts_match_boundary_corpus() {
+        let cache_dir = unique_temp_cache_dir();
+        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
+        let fragments = [
+            "",
+            "a",
+            "bc",
+            "  ",
+            "\n",
+            " \n ",
+            "punctuation!?",
+            "世界",
+            "设定。",
+            "\u{1f642}",
+            "e\u{301}",
+            "<|not-a-special-token|>",
+        ];
+
+        for model in ["gpt-4o", "gpt-4", "gpt-3.5-turbo-0301", "o1"] {
+            for base_index in 0..fragments.len() {
+                let base = fragments[..=base_index].concat();
+                let suffixes = (0..64)
+                    .map(|index| fragments[(base_index + index + 1) % fragments.len()].to_string())
+                    .collect::<Vec<_>>();
+                let actual = TokenizerRepository::count_system_message_prefixes(
+                    &repository,
+                    model,
+                    &base,
+                    &suffixes,
+                    None,
+                )
+                .expect("incremental prefix counts should succeed");
+
+                let mut content = base;
+                let expected = suffixes
+                    .iter()
+                    .map(|suffix| {
+                        content.push_str(suffix);
+                        TokenizerRepository::count_messages(
+                            &repository,
+                            model,
+                            &[json!({ "role": "system", "content": content })],
+                        )
+                        .expect("complete prefix count should succeed")
+                    })
+                    .collect::<Vec<_>>();
+
+                assert_eq!(actual, expected, "prefix counts changed for {model}");
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(cache_dir);
+    }
+
+    #[test]
+    fn openai_prefix_counts_preserve_stop_at_fill_semantics() {
+        let cache_dir = unique_temp_cache_dir();
+        let repository = MiktikTokenizerRepository::new(cache_dir.clone(), test_http_clients());
+        let suffixes = vec![
+            "short\n".to_string(),
+            "a considerably longer second entry\n".to_string(),
+            "this entry must not need to be tokenized\n".to_string(),
+        ];
+        let full_counts = TokenizerRepository::count_system_message_prefixes(
+            &repository,
+            "gpt-4o",
+            "base\n",
+            &suffixes,
+            None,
+        )
+        .expect("full prefix counts should succeed");
+        let stop_at = full_counts[1].saturating_sub(1);
+
+        let stopped_counts = TokenizerRepository::count_system_message_prefixes(
+            &repository,
+            "gpt-4o",
+            "base\n",
+            &suffixes,
+            Some(stop_at),
+        )
+        .expect("stopped prefix counts should succeed");
+
+        assert_eq!(
+            stopped_counts,
+            vec![full_counts[0], full_counts[1], full_counts[1]]
+        );
+        let _ = std::fs::remove_dir_all(cache_dir);
     }
 }

--- a/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
+++ b/src-tauri/crates/tt-adapter-tokenization/src/miktik_tokenizer_repository.rs
@@ -15,7 +15,7 @@ use tokio::sync::{Mutex, RwLock};
 use tt_adapter_http::{HttpClientPool, HttpClientProfile};
 use tt_domain::errors::DomainError;
 use tt_ports::repositories::tokenizer_repository::{
-    TokenizerRepository, count_system_message_prefixes_default,
+    TokenizerRepository, count_system_message_prefixes_default, has_reached_openai_text_token_limit,
 };
 
 const CLAUDE_JSON_GZIP_BYTES: &[u8] =
@@ -659,7 +659,7 @@ impl MiktikTokenizerRepository {
             let token_count = fixed_tokens.saturating_add(content_tokens).max(0) as usize;
             token_counts.push(token_count);
 
-            if stop_at.is_some_and(|limit| token_count.saturating_sub(1) >= limit) {
+            if has_reached_openai_text_token_limit(token_count, stop_at) {
                 token_counts.resize(suffixes.len(), token_count);
                 break;
             }
@@ -828,7 +828,9 @@ mod tests {
 
     use super::{MiktikTokenizerRepository, ModelSource, ResourceCompression};
     use tt_adapter_http::HttpClientPool;
-    use tt_ports::repositories::tokenizer_repository::TokenizerRepository;
+    use tt_ports::repositories::tokenizer_repository::{
+        TokenizerRepository, openai_text_token_count,
+    };
 
     const TEST_USER_AGENT: &str = "TauriTavern/test";
     static NEXT_TEMP_CACHE_DIR_ID: AtomicU64 = AtomicU64::new(0);
@@ -1289,7 +1291,7 @@ mod tests {
             None,
         )
         .expect("full prefix counts should succeed");
-        let stop_at = full_counts[1].saturating_sub(1);
+        let stop_at = openai_text_token_count(full_counts[1]);
 
         let stopped_counts = TokenizerRepository::count_system_message_prefixes(
             &repository,

--- a/src-tauri/crates/tt-application/src/dto/tokenization_dto.rs
+++ b/src-tauri/crates/tt-application/src/dto/tokenization_dto.rs
@@ -36,6 +36,18 @@ pub struct OpenAiTokenCountBatchResponseDto {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenAiTokenPrefixCountRequestDto {
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub base: String,
+    #[serde(default)]
+    pub suffixes: Vec<String>,
+    #[serde(default)]
+    pub stop_at: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OpenAiEncodeRequestDto {
     #[serde(default)]
     pub model: String,

--- a/src-tauri/crates/tt-application/src/dto/tokenization_dto.rs
+++ b/src-tauri/crates/tt-application/src/dto/tokenization_dto.rs
@@ -43,6 +43,8 @@ pub struct OpenAiTokenPrefixCountRequestDto {
     pub base: String,
     #[serde(default)]
     pub suffixes: Vec<String>,
+    /// Caller-visible text token threshold. The raw single-message wrapper
+    /// offset is excluded when deciding whether this limit has been reached.
     #[serde(default)]
     pub stop_at: Option<usize>,
 }

--- a/src-tauri/crates/tt-application/src/services/tokenization_service.rs
+++ b/src-tauri/crates/tt-application/src/services/tokenization_service.rs
@@ -6,7 +6,7 @@ use crate::dto::tokenization_dto::{
     LogitBiasEntryDto, OpenAiDecodeRequestDto, OpenAiDecodeResponseDto, OpenAiEncodeRequestDto,
     OpenAiEncodeResponseDto, OpenAiLogitBiasRequestDto, OpenAiLogitBiasResponseDto,
     OpenAiTokenCountBatchRequestDto, OpenAiTokenCountBatchResponseDto, OpenAiTokenCountRequestDto,
-    OpenAiTokenCountResponseDto,
+    OpenAiTokenCountResponseDto, OpenAiTokenPrefixCountRequestDto,
 };
 use crate::errors::ApplicationError;
 use tt_ports::repositories::tokenizer_repository::TokenizerRepository;
@@ -67,6 +67,34 @@ impl TokenizationService {
         .await
         .map_err(|error| {
             ApplicationError::InternalError(format!("Token count batch task failed: {error}"))
+        })??;
+
+        Ok(OpenAiTokenCountBatchResponseDto { token_counts })
+    }
+
+    pub async fn count_openai_token_prefixes(
+        &self,
+        dto: OpenAiTokenPrefixCountRequestDto,
+    ) -> Result<OpenAiTokenCountBatchResponseDto, ApplicationError> {
+        let model = self.normalize_model(&dto.model);
+        self.tokenizer_repository
+            .ensure_model_ready(model.as_ref())
+            .await?;
+
+        let tokenizer_repository = Arc::clone(&self.tokenizer_repository);
+        let model = model.into_owned();
+        let base = dto.base;
+        let suffixes = dto.suffixes;
+        let stop_at = dto.stop_at;
+
+        let token_counts = tokio::task::spawn_blocking(move || {
+            tokenizer_repository
+                .count_system_message_prefixes(&model, &base, &suffixes, stop_at)
+                .map_err(ApplicationError::from)
+        })
+        .await
+        .map_err(|error| {
+            ApplicationError::InternalError(format!("Token prefix count task failed: {error}"))
         })??;
 
         Ok(OpenAiTokenCountBatchResponseDto { token_counts })

--- a/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
+++ b/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
@@ -60,8 +60,10 @@ pub trait TokenizerRepository: Send + Sync {
     fn count_messages(&self, model: &str, messages: &[Value]) -> Result<usize, DomainError>;
 
     /// Counts cumulative system-message prefixes and returns raw
-    /// wrapper-inclusive message counts. `stop_at` is a caller-visible text
-    /// token threshold with the single-message wrapper offset excluded.
+    /// wrapper-inclusive message counts. Backends may use cumulative estimates,
+    /// but must refine the threshold boundary when `stop_at` is present so the
+    /// caller-visible budget decision remains unchanged. `stop_at` excludes the
+    /// single-message wrapper offset.
     fn count_system_message_prefixes(
         &self,
         model: &str,

--- a/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
+++ b/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
@@ -3,6 +3,23 @@ use serde_json::Value;
 
 use tt_domain::errors::DomainError;
 
+const OPENAI_MESSAGE_TO_TEXT_TOKEN_OFFSET: usize = 1;
+
+/// Converts a raw single-message OpenAI token count into the caller-visible
+/// text token count used by prefix budget checks.
+pub fn openai_text_token_count(message_token_count: usize) -> usize {
+    message_token_count.saturating_sub(OPENAI_MESSAGE_TO_TEXT_TOKEN_OFFSET)
+}
+
+/// Returns whether a raw single-message count has reached the caller-visible
+/// text token threshold supplied through `stop_at`.
+pub fn has_reached_openai_text_token_limit(
+    message_token_count: usize,
+    stop_at: Option<usize>,
+) -> bool {
+    stop_at.is_some_and(|limit| openai_text_token_count(message_token_count) >= limit)
+}
+
 pub fn count_system_message_prefixes_default<T: TokenizerRepository + ?Sized>(
     repository: &T,
     model: &str,
@@ -23,7 +40,7 @@ pub fn count_system_message_prefixes_default<T: TokenizerRepository + ?Sized>(
         let token_count = repository.count_messages(model, &[message])?;
         token_counts.push(token_count);
 
-        if stop_at.is_some_and(|limit| token_count.saturating_sub(1) >= limit) {
+        if has_reached_openai_text_token_limit(token_count, stop_at) {
             token_counts.resize(suffixes.len(), token_count);
             break;
         }
@@ -42,6 +59,9 @@ pub trait TokenizerRepository: Send + Sync {
 
     fn count_messages(&self, model: &str, messages: &[Value]) -> Result<usize, DomainError>;
 
+    /// Counts cumulative system-message prefixes and returns raw
+    /// wrapper-inclusive message counts. `stop_at` is a caller-visible text
+    /// token threshold with the single-message wrapper offset excluded.
     fn count_system_message_prefixes(
         &self,
         model: &str,
@@ -50,5 +70,20 @@ pub trait TokenizerRepository: Send + Sync {
         stop_at: Option<usize>,
     ) -> Result<Vec<usize>, DomainError> {
         count_system_message_prefixes_default(self, model, base, suffixes, stop_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_reached_openai_text_token_limit, openai_text_token_count};
+
+    #[test]
+    fn openai_text_token_threshold_excludes_the_message_wrapper_offset() {
+        assert_eq!(openai_text_token_count(0), 0);
+        assert_eq!(openai_text_token_count(1), 0);
+        assert_eq!(openai_text_token_count(13), 12);
+        assert!(has_reached_openai_text_token_limit(13, Some(12)));
+        assert!(!has_reached_openai_text_token_limit(12, Some(12)));
+        assert!(!has_reached_openai_text_token_limit(13, None));
     }
 }

--- a/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
+++ b/src-tauri/crates/tt-ports/src/repositories/tokenizer_repository.rs
@@ -3,6 +3,35 @@ use serde_json::Value;
 
 use tt_domain::errors::DomainError;
 
+pub fn count_system_message_prefixes_default<T: TokenizerRepository + ?Sized>(
+    repository: &T,
+    model: &str,
+    base: &str,
+    suffixes: &[String],
+    stop_at: Option<usize>,
+) -> Result<Vec<usize>, DomainError> {
+    let additional_capacity = suffixes
+        .iter()
+        .fold(0_usize, |total, suffix| total.saturating_add(suffix.len()));
+    let mut content = String::with_capacity(base.len().saturating_add(additional_capacity));
+    content.push_str(base);
+
+    let mut token_counts = Vec::with_capacity(suffixes.len());
+    for suffix in suffixes {
+        content.push_str(suffix);
+        let message = serde_json::json!({ "role": "system", "content": content });
+        let token_count = repository.count_messages(model, &[message])?;
+        token_counts.push(token_count);
+
+        if stop_at.is_some_and(|limit| token_count.saturating_sub(1) >= limit) {
+            token_counts.resize(suffixes.len(), token_count);
+            break;
+        }
+    }
+
+    Ok(token_counts)
+}
+
 #[async_trait]
 pub trait TokenizerRepository: Send + Sync {
     async fn ensure_model_ready(&self, model: &str) -> Result<(), DomainError>;
@@ -12,4 +41,14 @@ pub trait TokenizerRepository: Send + Sync {
     fn decode(&self, model: &str, token_ids: &[u32]) -> Result<String, DomainError>;
 
     fn count_messages(&self, model: &str, messages: &[Value]) -> Result<usize, DomainError>;
+
+    fn count_system_message_prefixes(
+        &self,
+        model: &str,
+        base: &str,
+        suffixes: &[String],
+        stop_at: Option<usize>,
+    ) -> Result<Vec<usize>, DomainError> {
+        count_system_message_prefixes_default(self, model, base, suffixes, stop_at)
+    }
 }

--- a/src/scripts/tokenizers.js
+++ b/src/scripts/tokenizers.js
@@ -701,7 +701,7 @@ export async function getTokenCountsAsync(strings, padding = undefined) {
  * @param {string} base Initial prefix shared by every result.
  * @param {string[]} suffixes Suffixes appended cumulatively in input order.
  * @param {number | undefined} padding Optional padding tokens.
- * @param {number | undefined} stopAt Stop after the first exact count at or above this value.
+ * @param {number | undefined} stopAt Caller-visible text token threshold; the single-message wrapper offset is excluded.
  * @returns {Promise<number[]>} Token counts for each cumulative prefix.
  */
 export async function getTokenPrefixCountsAsync(base, suffixes, padding = undefined, stopAt = undefined) {

--- a/src/scripts/tokenizers.js
+++ b/src/scripts/tokenizers.js
@@ -7,6 +7,12 @@ import { getStringHash } from './utils.js';
 import { kai_flags, kai_settings } from './kai-settings.js';
 import { textgen_types, textgenerationwebui_settings as textgen_settings, getTextGenServer, getTextGenModel } from './textgen-settings.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, openRouterModels } from './textgen-models.js';
+import {
+    getOpenAIConversationTokenCount,
+    getOpenAITextTokenCount,
+    hasReachedOpenAITextTokenLimit,
+} from './util/openai-token-count.js';
+import { createSingleFlight } from './util/single-flight.js';
 
 export const CHARACTERS_PER_TOKEN_RATIO = 3.35;
 export const TOKENIZER_WARNING_KEY = 'tokenizationWarningShown';
@@ -35,6 +41,8 @@ export const tokenizers = {
     COMMAND_A: 19,
     BEST_MATCH: 99,
 };
+
+const countTokenPrefixesSingleFlight = createSingleFlight();
 
 // A list of local tokenizers that support encoding and decoding token ids.
 export const ENCODE_TOKENIZERS = [
@@ -667,6 +675,108 @@ function counterWrapperOpenAIAsync(text) {
     return countTokensOpenAIAsync(message, true);
 }
 
+/**
+ * Gets exact token counts for multiple strings using the active tokenizer.
+ * Results preserve input order and match individual getTokenCountAsync calls.
+ * @param {string[]} strings Strings to tokenize.
+ * @param {number | undefined} padding Optional padding tokens.
+ * @returns {Promise<number[]>} Token counts in input order.
+ */
+export async function getTokenCountsAsync(strings, padding = undefined) {
+    if (!Array.isArray(strings)) {
+        throw new TypeError('getTokenCountsAsync expects an array');
+    }
+
+    if (main_api === 'openai' && padding !== power_user.token_padding) {
+        const messages = strings.map(text => ({ role: 'system', content: text }));
+        const counts = await countOpenAIMessageTokensBatchAsync(messages);
+        return counts.map((count, index) => strings[index]?.length ? getOpenAITextTokenCount(count) : 0);
+    }
+
+    return Promise.all(strings.map(text => getTokenCountAsync(text, padding)));
+}
+
+/**
+ * Gets exact token counts for cumulative prefixes without sending every expanded prefix.
+ * @param {string} base Initial prefix shared by every result.
+ * @param {string[]} suffixes Suffixes appended cumulatively in input order.
+ * @param {number | undefined} padding Optional padding tokens.
+ * @param {number | undefined} stopAt Stop after the first exact count at or above this value.
+ * @returns {Promise<number[]>} Token counts for each cumulative prefix.
+ */
+export async function getTokenPrefixCountsAsync(base, suffixes, padding = undefined, stopAt = undefined) {
+    if (typeof base !== 'string' || !Array.isArray(suffixes)) {
+        throw new TypeError('getTokenPrefixCountsAsync expects a string base and an array of suffixes');
+    }
+
+    if (main_api === 'openai' && padding !== power_user.token_padding && globalThis.__TAURITAVERN__) {
+        const model = getTokenizerModel();
+        const cacheState = getTokenCacheState(resolveTokenCacheChatId());
+        if (cacheState.loadPromise) {
+            await cacheState.loadPromise;
+        }
+
+        const cacheKeys = [];
+        const cachedCounts = [];
+        let prefix = base;
+        let allCached = true;
+        for (let index = 0; index < suffixes.length; index++) {
+            prefix += suffixes[index];
+            const message = { role: 'system', content: prefix };
+            const cacheKey = `${model}-${getStringHash(JSON.stringify(message))}`;
+            cacheKeys.push(cacheKey);
+            const cachedCount = cacheState.cache[cacheKey];
+            cachedCounts.push(cachedCount);
+            allCached &&= typeof cachedCount === 'number';
+            if (allCached && hasReachedOpenAITextTokenLimit(cachedCount, stopAt)) {
+                return suffixes.map((_, countIndex) => getOpenAITextTokenCount(cachedCounts[Math.min(countIndex, index)]));
+            }
+        }
+
+        if (allCached) {
+            return cachedCounts.map(getOpenAITextTokenCount);
+        }
+
+        try {
+            const requestBody = JSON.stringify({ base, suffixes, stop_at: stopAt });
+            const requestKey = `${model}\n${requestBody}`;
+            const data = await countTokenPrefixesSingleFlight(requestKey, () => jQuery.ajax({
+                async: true,
+                type: 'POST',
+                url: `/api/tokenizers/openai/count-prefix-batch?model=${model}`,
+                data: requestBody,
+                dataType: 'json',
+                contentType: 'application/json',
+            }));
+
+            if (Array.isArray(data?.token_counts) && data.token_counts.length === suffixes.length) {
+                for (let index = 0; index < data.token_counts.length; index++) {
+                    const count = data.token_counts[index];
+                    const numericCount = Number(count);
+                    if (Number.isFinite(numericCount)) {
+                        cacheState.cache[cacheKeys[index]] = numericCount;
+                        cacheState.dirty = true;
+                    }
+                    if (hasReachedOpenAITextTokenLimit(numericCount, stopAt)) {
+                        break;
+                    }
+                }
+                return data.token_counts.map(getOpenAITextTokenCount);
+            }
+        } catch (error) {
+            console.warn('OpenAI token prefix count request failed, using exact batch fallback:', error);
+        }
+    }
+
+    const prefixes = [];
+    let prefix = base;
+    for (const suffix of suffixes) {
+        prefix += suffix;
+        prefixes.push(prefix);
+    }
+    return getTokenCountsAsync(prefixes, padding);
+}
+
 export function getTokenizerModel(settings = null) {
     const oai_settings = settings ?? current_oai_settings;
     // OpenAI models always provide their own tokenizer
@@ -1070,6 +1180,27 @@ export function countTokensOpenAI(messages, full = false) {
  */
 export async function countTokensOpenAIAsync(messages, full = false, settings = null) {
     const model = getTokenizerModel(settings);
+
+    if (!Array.isArray(messages)) {
+        messages = [messages];
+    }
+
+    if (model === 'claude') {
+        full = true;
+    }
+
+    const counts = await countOpenAIMessageTokensBatchAsync(messages, settings);
+    return getOpenAIConversationTokenCount(counts, full);
+}
+
+/**
+ * Counts OpenAI-style messages independently in one batch while preserving order.
+ * @param {object[]} messages Messages to count independently.
+ * @param {ChatCompletionSettings|null} settings Optional model settings.
+ * @returns {Promise<number[]>} Per-message token counts.
+ */
+async function countOpenAIMessageTokensBatchAsync(messages, settings = null) {
+    const model = getTokenizerModel(settings);
     const tokenizerEndpoint = `/api/tokenizers/openai/count-batch?model=${model}`;
     const legacyTokenizerEndpoint = `/api/tokenizers/openai/count?model=${model}`;
     const cacheState = getTokenCacheState(resolveTokenCacheChatId());
@@ -1077,32 +1208,26 @@ export async function countTokensOpenAIAsync(messages, full = false, settings = 
         await cacheState.loadPromise;
     }
     const cacheObject = cacheState.cache;
-
-    if (!Array.isArray(messages)) {
-        messages = [messages];
-    }
-
-    let token_count = -1;
-
-    if (model === 'claude') {
-        full = true;
-    }
+    const counts = new Array(messages.length);
 
     const cacheMisses = [];
     const cacheMissKeys = [];
+    const cacheMissIndices = [];
 
-    for (const message of messages) {
+    for (let index = 0; index < messages.length; index++) {
+        const message = messages[index];
         const hash = getStringHash(JSON.stringify(message));
         const cacheKey = `${model}-${hash}`;
         const cachedCount = cacheObject[cacheKey];
 
         if (typeof cachedCount === 'number') {
-            token_count += cachedCount;
+            counts[index] = cachedCount;
         }
 
         else {
             cacheMisses.push(message);
             cacheMissKeys.push(cacheKey);
+            cacheMissIndices.push(index);
         }
     }
 
@@ -1156,7 +1281,7 @@ export async function countTokensOpenAIAsync(messages, full = false, settings = 
                 count = guesstimateOpenAiMessageTokenCount(cacheMisses[i]);
             }
 
-            token_count += count;
+            counts[cacheMissIndices[i]] = count;
             if (shouldCache) {
                 cacheObject[cacheMissKeys[i]] = count;
                 cacheState.dirty = true;
@@ -1164,9 +1289,7 @@ export async function countTokensOpenAIAsync(messages, full = false, settings = 
         }
     }
 
-    if (!full) token_count -= 2;
-
-    return token_count;
+    return counts;
 }
 
 /**

--- a/src/scripts/util/openai-token-count.js
+++ b/src/scripts/util/openai-token-count.js
@@ -1,6 +1,7 @@
 const OPENAI_MESSAGE_TO_TEXT_OFFSET = 1;
 const OPENAI_NON_FULL_CONVERSATION_OFFSET = 2;
 
+/** Converts a raw single-message count into its caller-visible text count. */
 export function getOpenAITextTokenCount(messageTokenCount) {
     return Number(messageTokenCount) - OPENAI_MESSAGE_TO_TEXT_OFFSET;
 }
@@ -14,6 +15,7 @@ export function getOpenAIConversationTokenCount(messageTokenCounts, full = false
     return full ? tokenCount : tokenCount - OPENAI_NON_FULL_CONVERSATION_OFFSET;
 }
 
+/** Compares a raw single-message count with a caller-visible text threshold. */
 export function hasReachedOpenAITextTokenLimit(messageTokenCount, stopAt) {
     return Number.isFinite(stopAt) && getOpenAITextTokenCount(messageTokenCount) >= stopAt;
 }

--- a/src/scripts/util/openai-token-count.js
+++ b/src/scripts/util/openai-token-count.js
@@ -1,0 +1,19 @@
+const OPENAI_MESSAGE_TO_TEXT_OFFSET = 1;
+const OPENAI_NON_FULL_CONVERSATION_OFFSET = 2;
+
+export function getOpenAITextTokenCount(messageTokenCount) {
+    return Number(messageTokenCount) - OPENAI_MESSAGE_TO_TEXT_OFFSET;
+}
+
+export function getOpenAIConversationTokenCount(messageTokenCounts, full = false) {
+    const tokenCount = messageTokenCounts.reduce(
+        (total, count) => total + Number(count),
+        -OPENAI_MESSAGE_TO_TEXT_OFFSET,
+    );
+
+    return full ? tokenCount : tokenCount - OPENAI_NON_FULL_CONVERSATION_OFFSET;
+}
+
+export function hasReachedOpenAITextTokenLimit(messageTokenCount, stopAt) {
+    return Number.isFinite(stopAt) && getOpenAITextTokenCount(messageTokenCount) >= stopAt;
+}

--- a/src/scripts/util/single-flight.js
+++ b/src/scripts/util/single-flight.js
@@ -1,0 +1,25 @@
+/**
+ * Shares an in-flight promise for callers using the same exact key.
+ * Settled results are never retained.
+ *
+ * @template T
+ * @returns {(key: string, task: () => Promise<T>) => Promise<T>}
+ */
+export function createSingleFlight() {
+    /** @type {Map<string, Promise<T>>} */
+    const inFlight = new Map();
+
+    return function runSingleFlight(key, task) {
+        const existing = inFlight.get(key);
+        if (existing) return existing;
+
+        const promise = Promise.resolve().then(task);
+        inFlight.set(key, promise);
+        void promise.finally(() => {
+            if (inFlight.get(key) === promise) {
+                inFlight.delete(key);
+            }
+        }).catch(() => {});
+        return promise;
+    };
+}

--- a/src/scripts/world-info-entry-prepare.js
+++ b/src/scripts/world-info-entry-prepare.js
@@ -1,0 +1,16 @@
+/**
+ * Parses decorators and hashes entries without retaining an intermediate entry array.
+ * Hash input and property order match the legacy two-map implementation.
+ * @param {object[]} entries
+ * @param {(content: string) => [string[], string]} parseDecorators
+ * @param {(value: string) => number} getStringHash
+ * @returns {object[]}
+ */
+export function prepareWorldInfoEntries(entries, parseDecorators, getStringHash) {
+    return entries.map((entry) => {
+        const [decorators, content] = parseDecorators(entry.content || '');
+        const preparedEntry = { ...entry, decorators, content };
+        preparedEntry.hash = getStringHash(JSON.stringify(preparedEntry));
+        return preparedEntry;
+    });
+}

--- a/src/scripts/world-info-token-prefetch.js
+++ b/src/scripts/world-info-token-prefetch.js
@@ -1,0 +1,25 @@
+const DEFAULT_WORLD_INFO_TOKEN_BATCH_SIZE = 64;
+
+export function canPrefetchWorldInfoTokenCount(entry) {
+    return !entry.ignoreBudget
+        && (!entry.useProbability || entry.probability === 100)
+        && !String(entry.content ?? '').includes('{')
+        && !String(entry.content ?? '').includes('<');
+}
+
+export function getWorldInfoTokenPrefetchBatch(entries, startIndex, maxEntries = DEFAULT_WORLD_INFO_TOKEN_BATCH_SIZE) {
+    const batchEntries = [];
+    const suffixes = [];
+
+    for (let index = startIndex; index < entries.length && batchEntries.length < maxEntries; index++) {
+        const entry = entries[index];
+        if (!canPrefetchWorldInfoTokenCount(entry)) {
+            break;
+        }
+
+        batchEntries.push(entry);
+        suffixes.push(`${entry.content}\n`);
+    }
+
+    return { entries: batchEntries, suffixes };
+}

--- a/src/scripts/world-info.js
+++ b/src/scripts/world-info.js
@@ -7,7 +7,7 @@ import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
-import { getTokenCountAsync } from './tokenizers.js';
+import { getTokenCountAsync, getTokenPrefixCountsAsync } from './tokenizers.js';
 import { power_user } from './power-user.js';
 import { getTagKeyForEntity } from './tags.js';
 import { debounce_timeout, GENERATION_TYPE_TRIGGERS } from './constants.js';
@@ -26,6 +26,8 @@ import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
 import { normalizeWorldInfoActivationBatch } from './tauritavern/agent/world-info-activation.js';
 import { registerLifecycleFlushHandler } from '../tauri/main/services/lifecycle/lifecycle-flush-service.js';
+import { canPrefetchWorldInfoTokenCount, getWorldInfoTokenPrefetchBatch } from './world-info-token-prefetch.js';
+import { prepareWorldInfoEntries } from './world-info-entry-prepare.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -1111,7 +1113,7 @@ export function setWorldInfoSettings(settings, data) {
         const hasWorldInfo = !!chat_metadata[METADATA_KEY] && world_names.includes(chat_metadata[METADATA_KEY]);
         $('.chat_lorebook_button').toggleClass('world_set', hasWorldInfo);
         // Pre-cache the world info data for the chat for quicker first prompt generation
-        await getSortedEntries();
+        await preloadWorldInfoEntries();
     });
 
     eventSource.on(event_types.WORLDINFO_FORCE_ACTIVATE, (entries) => {
@@ -4760,73 +4762,78 @@ async function getPersonaLore() {
     return entries;
 }
 
+async function collectWorldInfoEntries() {
+    const worldsToPrefetch = new Set();
+    for (const worldName of selected_world_info || []) {
+        worldsToPrefetch.add(worldName);
+    }
+
+    const { worldsToSearch } = collectCharacterWorldsToSearch();
+    for (const worldName of worldsToSearch) {
+        worldsToPrefetch.add(worldName);
+    }
+
+    const chatWorld = chat_metadata[METADATA_KEY];
+    if (chatWorld) {
+        worldsToPrefetch.add(chatWorld);
+    }
+
+    const personaWorld = power_user.persona_description_lorebook;
+    if (personaWorld) {
+        worldsToPrefetch.add(personaWorld);
+    }
+
+    await prefetchWorldInfos(worldsToPrefetch);
+
+    const [
+        globalLore,
+        characterLore,
+        chatLore,
+        personaLore,
+    ] = await Promise.all([
+        getGlobalLore(),
+        getCharacterLore(),
+        getChatLore(),
+        getPersonaLore(),
+    ]);
+
+    await eventSource.emit(event_types.WORLDINFO_ENTRIES_LOADED, { globalLore, characterLore, chatLore, personaLore });
+
+    return { globalLore, characterLore, chatLore, personaLore };
+}
+
+async function preloadWorldInfoEntries() {
+    try {
+        await collectWorldInfoEntries();
+    } catch (error) {
+        console.error(error);
+    }
+}
+
 export async function getSortedEntries() {
     try {
-        const worldsToPrefetch = new Set();
-        for (const worldName of selected_world_info || []) {
-            worldsToPrefetch.add(worldName);
-        }
+        const { globalLore, characterLore, chatLore, personaLore } = await collectWorldInfoEntries();
 
-        const { worldsToSearch } = collectCharacterWorldsToSearch();
-        for (const worldName of worldsToSearch) {
-            worldsToPrefetch.add(worldName);
-        }
-
-        const chatWorld = chat_metadata[METADATA_KEY];
-        if (chatWorld) {
-            worldsToPrefetch.add(chatWorld);
-        }
-
-        const personaWorld = power_user.persona_description_lorebook;
-        if (personaWorld) {
-            worldsToPrefetch.add(personaWorld);
-        }
-
-        await prefetchWorldInfos(worldsToPrefetch);
-
-        const [
-            globalLore,
-            characterLore,
-            chatLore,
-            personaLore,
-        ] = await Promise.all([
-            getGlobalLore(),
-            getCharacterLore(),
-            getChatLore(),
-            getPersonaLore(),
-        ]);
-
-        await eventSource.emit(event_types.WORLDINFO_ENTRIES_LOADED, { globalLore, characterLore, chatLore, personaLore });
-
-        let entries;
-
+        let sorted;
         switch (Number(world_info_character_strategy)) {
             case world_info_insertion_strategy.evenly:
-                entries = [...globalLore, ...characterLore].sort(sortFn);
+                sorted = [...globalLore, ...characterLore].sort(sortFn);
                 break;
             case world_info_insertion_strategy.character_first:
-                entries = [...characterLore.sort(sortFn), ...globalLore.sort(sortFn)];
+                sorted = [...characterLore.sort(sortFn), ...globalLore.sort(sortFn)];
                 break;
             case world_info_insertion_strategy.global_first:
-                entries = [...globalLore.sort(sortFn), ...characterLore.sort(sortFn)];
+                sorted = [...globalLore.sort(sortFn), ...characterLore.sort(sortFn)];
                 break;
             default:
                 console.error('[WI] Unknown WI insertion strategy:', world_info_character_strategy, 'defaulting to evenly');
-                entries = [...globalLore, ...characterLore].sort(sortFn);
+                sorted = [...globalLore, ...characterLore].sort(sortFn);
                 break;
         }
 
         // Chat lore always goes first, then persona lore, then the rest
-        entries = [...chatLore.sort(sortFn), ...personaLore.sort(sortFn), ...entries];
-
-        // Calculate hash and parse decorators. Split maps to preserve old hashes.
-        entries = entries.map((entry) => {
-            const [decorators, content] = parseDecorators(entry.content || '');
-            return { ...entry, decorators, content };
-        }).map((entry) => {
-            const hash = getStringHash(JSON.stringify(entry));
-            return { ...entry, hash };
-        });
+        let entries = [...chatLore.sort(sortFn), ...personaLore.sort(sortFn), ...sorted];
+        entries = prepareWorldInfoEntries(entries, parseDecorators, getStringHash);
 
         console.debug(`[WI] Found ${entries.length} world lore entries. Sorted by strategy`, Object.entries(world_info_insertion_strategy).find((x) => x[1] === world_info_character_strategy));
 
@@ -4905,6 +4912,10 @@ function parseDecorators(content) {
  */
 //MARK: checkWorldInfo
 export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData = defaultGlobalScanData) {
+    return checkWorldInfoInternal(chat, maxContext, isDryRun, globalScanData);
+}
+
+async function checkWorldInfoInternal(chat, maxContext, isDryRun, globalScanData) {
     const context = getContext();
     const buffer = new WorldInfoBuffer(chat, globalScanData);
 
@@ -4979,7 +4990,6 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
         // Loop and find all entries that can activate here
         let activatedNow = new Set();
-
         for (const entry of sortedEntries) {
             // Logging preparation
             let headerLogged = false;
@@ -5185,7 +5195,6 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             activatedNow.add(entry);
             continue;
         }
-
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
 
         // Sort the entries for the probability and the budget limit checks
@@ -5210,7 +5219,10 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
         let ignoresBudget = newEntries.filter(e => e.ignoreBudget).length;
 
-        for (const entry of newEntries) {
+        const prefetchedTokenCounts = new Map();
+
+        for (let entryIndex = 0; entryIndex < newEntries.length; entryIndex++) {
+            const entry = newEntries[entryIndex];
             ignoresBudget -= (entry.ignoreBudget ? 1 : 0);
             if (token_budget_overflowed && !entry.ignoreBudget) {
                 if (ignoresBudget > 0) {
@@ -5250,9 +5262,23 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
             // Substitute macros inline, for both this checking and also future processing
             entry.content = substituteParams(entry.content);
+            const batchBaseContent = newContent;
             newContent += `${entry.content}\n`;
 
-            if (!entry.ignoreBudget && (textToScanTokens + (await getTokenCountAsync(newContent))) >= budget) {
+            if (canPrefetchWorldInfoTokenCount(entry) && !prefetchedTokenCounts.has(entry)) {
+                const { entries: batchEntries, suffixes: batchSuffixes } = getWorldInfoTokenPrefetchBatch(newEntries, entryIndex);
+
+                const remainingBudget = budget - textToScanTokens;
+                const batchCounts = await getTokenPrefixCountsAsync(batchBaseContent, batchSuffixes, undefined, remainingBudget);
+                batchEntries.forEach((batchEntry, index) => prefetchedTokenCounts.set(batchEntry, batchCounts[index]));
+            }
+
+            const newContentTokens = entry.ignoreBudget
+                ? 0
+                : prefetchedTokenCounts.has(entry)
+                    ? prefetchedTokenCounts.get(entry)
+                    : await getTokenCountAsync(newContent);
+            if (!entry.ignoreBudget && (textToScanTokens + newContentTokens) >= budget) {
                 if (!token_budget_overflowed) {
                     console.debug('[WI] --- BUDGET OVERFLOW CHECK ---');
                     if (world_info_overflow_alert) {

--- a/src/tauri/main/kernel/invokes/invoke-policies.js
+++ b/src/tauri/main/kernel/invokes/invoke-policies.js
@@ -44,6 +44,12 @@ function countOpenAiTokensBatchKey(args) {
     return fnv1a32(json);
 }
 
+/** @param {any} args */
+function exactTokenizerRequestKey(args) {
+    const dto = args?.dto ?? args ?? {};
+    return JSON.stringify(dto);
+}
+
 /**
  * @param {any} args
  * @returns {string}
@@ -88,6 +94,11 @@ export function createHostInvokePolicies() {
             cacheTtlMs: 2_000,
             cacheLimit: 50,
             key: countOpenAiTokensBatchKey,
+        },
+        count_openai_token_prefixes: {
+            kind: 'dedupe',
+            maxConcurrent: 1,
+            key: exactTokenizerRequestKey,
         },
         get_openrouter_model_providers: {
             kind: 'dedupe',

--- a/src/tauri/main/kernel/invokes/tauri-commands.js
+++ b/src/tauri/main/kernel/invokes/tauri-commands.js
@@ -19,6 +19,7 @@ export {};
  *   | 'cancel_data_archive_job'
  *   | 'cleanup_export_data_archive'
  *   | 'cleanup_user_backup_archive'
+ *   | 'count_openai_token_prefixes'
  *   | 'count_openai_tokens_batch'
  *   | 'assign_images_to_metadata_folder'
  *   | 'create_character'

--- a/src/tauri/main/routes/openai-tokenizer-routes.js
+++ b/src/tauri/main/routes/openai-tokenizer-routes.js
@@ -58,6 +58,23 @@ export function registerOpenAiTokenizerRoutes(router, context, { jsonResponse })
         }
     });
 
+    router.post('/api/tokenizers/openai/count-prefix-batch', async ({ body, url }) => {
+        const model = String(url?.searchParams?.get('model') || '');
+        const payload = asObject(body);
+        if (typeof payload.base !== 'string' || !Array.isArray(payload.suffixes) || payload.suffixes.some(suffix => typeof suffix !== 'string')) {
+            return jsonResponse({ error: 'OpenAI token prefix count body must contain a string base and string suffixes' }, 400);
+        }
+
+        const stopAt = Number.isSafeInteger(payload.stop_at) && payload.stop_at >= 0 ? payload.stop_at : null;
+        const dto = { model, base: payload.base, suffixes: payload.suffixes, stop_at: stopAt };
+        try {
+            return jsonResponse(await context.safeInvoke('count_openai_token_prefixes', { dto }));
+        } catch (error) {
+            console.warn('OpenAI token prefix count failed:', error);
+            return jsonResponse({ error: getErrorMessage(error) }, 500);
+        }
+    });
+
     router.post('/api/tokenizers/openai/encode', async ({ body, url }) => {
         const model = String(url?.searchParams?.get('model') || '');
         const payload = asObject(body);

--- a/tests/openai-token-count.test.mjs
+++ b/tests/openai-token-count.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    getOpenAIConversationTokenCount,
+    getOpenAITextTokenCount,
+    hasReachedOpenAITextTokenLimit,
+} from '../src/scripts/util/openai-token-count.js';
+
+test('OpenAI token count helpers preserve text and conversation offsets', () => {
+    assert.equal(getOpenAITextTokenCount(8), 7);
+    assert.equal(getOpenAIConversationTokenCount([8, 13], true), 20);
+    assert.equal(getOpenAIConversationTokenCount([8, 13]), 18);
+});
+
+test('OpenAI token limit uses the caller-visible text count', () => {
+    assert.equal(hasReachedOpenAITextTokenLimit(13, 12), true);
+    assert.equal(hasReachedOpenAITextTokenLimit(12, 12), false);
+    assert.equal(hasReachedOpenAITextTokenLimit(13, undefined), false);
+});

--- a/tests/openai-tokenizer-routes-contract.test.mjs
+++ b/tests/openai-tokenizer-routes-contract.test.mjs
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import { jsonResponse } from '../src/tauri/main/http-utils.js';
 import { createRouteRegistry } from '../src/tauri/main/router.js';
 import { createTokenCountBroker } from '../src/tauri/main/brokers/token-count-broker.js';
 import { registerOpenAiTokenizerRoutes } from '../src/tauri/main/routes/openai-tokenizer-routes.js';
+
+test('OpenAI token prefix count command is part of the centralized invoke contract', async () => {
+    const source = await readFile(new URL('../src/tauri/main/kernel/invokes/tauri-commands.js', import.meta.url), 'utf8');
+
+    assert.match(source, /\| 'count_openai_token_prefixes'/);
+});
 
 test('OpenAI token count broker preserves all message fields', async () => {
     let capturedDto;
@@ -88,4 +95,59 @@ test('OpenAI token count batch route still invokes backend for empty warm batch'
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), { token_counts: [] });
     assert.deepEqual(capturedDto, { model: 'gpt-4o', requests: [] });
+});
+
+test('OpenAI token prefix count route preserves compact prefix parts', async () => {
+    let capturedDto;
+    const router = createRouteRegistry();
+    registerOpenAiTokenizerRoutes(
+        router,
+        {
+            async safeInvoke(command, { dto }) {
+                assert.equal(command, 'count_openai_token_prefixes');
+                capturedDto = dto;
+                return { token_counts: [8, 13] };
+            },
+        },
+        { jsonResponse },
+    );
+
+    const response = await router.handle({
+        method: 'POST',
+        path: '/api/tokenizers/openai/count-prefix-batch',
+        url: new URL('http://tauri.local/api/tokenizers/openai/count-prefix-batch?model=gpt-4o'),
+        body: { base: 'base', suffixes: [' one', ' two'], stop_at: 12 },
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { token_counts: [8, 13] });
+    assert.deepEqual(capturedDto, { model: 'gpt-4o', base: 'base', suffixes: [' one', ' two'], stop_at: 12 });
+});
+
+test('OpenAI token prefix count route rejects invalid prefix parts', async () => {
+    let invokeCount = 0;
+    const router = createRouteRegistry();
+    registerOpenAiTokenizerRoutes(
+        router,
+        {
+            async safeInvoke() {
+                invokeCount += 1;
+                throw new Error('safeInvoke should not run for an invalid request body');
+            },
+        },
+        { jsonResponse },
+    );
+
+    const response = await router.handle({
+        method: 'POST',
+        path: '/api/tokenizers/openai/count-prefix-batch',
+        url: new URL('http://tauri.local/api/tokenizers/openai/count-prefix-batch?model=gpt-4o'),
+        body: { base: 42, suffixes: ['valid', 7] },
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+        error: 'OpenAI token prefix count body must contain a string base and string suffixes',
+    });
+    assert.equal(invokeCount, 0);
 });

--- a/tests/single-flight.test.mjs
+++ b/tests/single-flight.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSingleFlight } from '../src/scripts/util/single-flight.js';
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+test('identical concurrent keys share one task and result', async () => {
+    const gate = deferred();
+    const singleFlight = createSingleFlight();
+    let calls = 0;
+    const task = () => {
+        calls += 1;
+        return gate.promise;
+    };
+
+    const first = singleFlight('same', task);
+    const second = singleFlight('same', task);
+    await Promise.resolve();
+    assert.equal(calls, 1);
+
+    gate.resolve([1, 2, 3]);
+    assert.strictEqual(await first, await second);
+});
+
+test('different keys run independently', async () => {
+    const singleFlight = createSingleFlight();
+    const values = await Promise.all([
+        singleFlight('first', async () => 1),
+        singleFlight('second', async () => 2),
+    ]);
+
+    assert.deepEqual(values, [1, 2]);
+});
+
+test('settled success and failure entries are removed', async () => {
+    const singleFlight = createSingleFlight();
+    let calls = 0;
+
+    assert.equal(await singleFlight('success', async () => ++calls), 1);
+    await Promise.resolve();
+    assert.equal(await singleFlight('success', async () => ++calls), 2);
+
+    await assert.rejects(singleFlight('failure', async () => {
+        calls += 1;
+        throw new Error('expected failure');
+    }), /expected failure/);
+    await Promise.resolve();
+    assert.equal(await singleFlight('failure', async () => ++calls), 4);
+});

--- a/tests/tokenizer-invoke-policy.test.mjs
+++ b/tests/tokenizer-invoke-policy.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createInvokeBroker } from '../src/tauri/main/brokers/invoke-broker.js';
+import { createHostInvokePolicies } from '../src/tauri/main/kernel/invokes/invoke-policies.js';
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+test('token prefix policy deduplicates exact requests and serializes distinct native work', async () => {
+    const gates = [deferred(), deferred()];
+    const calls = [];
+    let active = 0;
+    let maxActive = 0;
+    const broker = createInvokeBroker({
+        policies: createHostInvokePolicies(),
+        transport: async (command, args) => {
+            assert.equal(command, 'count_openai_token_prefixes');
+            const index = calls.length;
+            calls.push(args);
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await gates[index].promise;
+            active -= 1;
+            return { token_counts: [index + 1] };
+        },
+    });
+
+    const firstArgs = { dto: { model: 'gpt-4o', base: 'a', suffixes: ['b'], stop_at: 10 } };
+    const secondArgs = { dto: { model: 'gpt-4o', base: 'x', suffixes: ['y'], stop_at: 10 } };
+    const first = broker.invoke('count_openai_token_prefixes', firstArgs);
+    const duplicate = broker.invoke('count_openai_token_prefixes', structuredClone(firstArgs));
+    const second = broker.invoke('count_openai_token_prefixes', secondArgs);
+
+    await Promise.resolve();
+    assert.equal(calls.length, 1);
+    assert.equal(maxActive, 1);
+
+    gates[0].resolve();
+    assert.deepEqual(await first, { token_counts: [1] });
+    assert.deepEqual(await duplicate, { token_counts: [1] });
+    await Promise.resolve();
+    assert.equal(calls.length, 2);
+    assert.equal(maxActive, 1);
+
+    gates[1].resolve();
+    assert.deepEqual(await second, { token_counts: [2] });
+    assert.deepEqual(calls, [firstArgs, secondArgs]);
+});
+
+test('token prefix policy does not cache settled results', async () => {
+    let calls = 0;
+    const broker = createInvokeBroker({
+        policies: createHostInvokePolicies(),
+        transport: async () => ({ token_counts: [++calls] }),
+    });
+    const args = { dto: { model: 'gpt-4o', base: 'a', suffixes: ['b'], stop_at: null } };
+
+    assert.deepEqual(await broker.invoke('count_openai_token_prefixes', args), { token_counts: [1] });
+    assert.deepEqual(await broker.invoke('count_openai_token_prefixes', args), { token_counts: [2] });
+});
+
+test('token prefix policy uses the complete DTO as its dedupe identity', () => {
+    const policy = createHostInvokePolicies().count_openai_token_prefixes;
+    const first = { dto: { model: 'gpt-4o', base: 'a', suffixes: ['b'], stop_at: 10 } };
+    const second = { dto: { model: 'gpt-4o', base: 'a', suffixes: ['c'], stop_at: 10 } };
+
+    assert.equal(policy.key(first), JSON.stringify(first.dto));
+    assert.notEqual(policy.key(first), policy.key(second));
+});

--- a/tests/world-info-chat-preload-contract.test.mjs
+++ b/tests/world-info-chat-preload-contract.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('chat changes preload world info without preparing discarded entries', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/world-info.js'), 'utf8');
+    const chatChangedHandler = source.match(/eventSource\.on\(event_types\.CHAT_CHANGED,[\s\S]*?\n\s*}\);/)?.[0] ?? '';
+    const preloadFunction = source.match(/async function preloadWorldInfoEntries\(\)[\s\S]*?\n}\n\nexport async function getSortedEntries/)?.[0] ?? '';
+    const sortedFunction = source.match(/export async function getSortedEntries[\s\S]*?\n}\n\n\n\/\*\*/)?.[0] ?? '';
+
+    assert.match(chatChangedHandler, /await preloadWorldInfoEntries\(\);/);
+    assert.doesNotMatch(chatChangedHandler, /getSortedEntries\(/);
+
+    assert.match(preloadFunction, /await collectWorldInfoEntries\(\);/);
+    assert.doesNotMatch(preloadFunction, /prepareWorldInfoEntries|structuredClone|entries-sort/);
+
+    assert.match(sortedFunction, /await collectWorldInfoEntries\(\)/);
+    assert.match(sortedFunction, /prepareWorldInfoEntries/);
+    assert.match(sortedFunction, /structuredClone\(entries\)/);
+});
+
+test('world info collection preserves prefetch and loaded-event behavior', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/world-info.js'), 'utf8');
+    const collectFunction = source.match(/async function collectWorldInfoEntries[\s\S]*?\n}\n\nasync function preloadWorldInfoEntries/)?.[0] ?? '';
+
+    assert.match(collectFunction, /prefetchWorldInfos\(worldsToPrefetch\)/);
+    assert.match(collectFunction, /getGlobalLore\(\)/);
+    assert.match(collectFunction, /getCharacterLore\(\)/);
+    assert.match(collectFunction, /getChatLore\(\)/);
+    assert.match(collectFunction, /getPersonaLore\(\)/);
+    assert.match(collectFunction, /eventSource\.emit\(event_types\.WORLDINFO_ENTRIES_LOADED, \{ globalLore, characterLore, chatLore, personaLore \}\)/);
+});

--- a/tests/world-info-entry-prepare.test.mjs
+++ b/tests/world-info-entry-prepare.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { prepareWorldInfoEntries } from '../src/scripts/world-info-entry-prepare.js';
+
+function legacyPrepare(entries, parseDecorators, getStringHash) {
+    return entries.map((entry) => {
+        const [decorators, content] = parseDecorators(entry.content || '');
+        return { ...entry, decorators, content };
+    }).map((entry) => {
+        const hash = getStringHash(JSON.stringify(entry));
+        return { ...entry, hash };
+    });
+}
+
+test('world info entry preparation preserves legacy objects and hash inputs', () => {
+    const entries = [
+        { uid: 1, world: 'global', content: '@@@depth 2\nalpha', enabled: true, order: 10 },
+        { uid: '2', world: 'chat', content: '', probability: 75, nested: { value: true } },
+        { uid: 3, world: 'persona', content: null, hash: 123, extra: ['a', 'b'] },
+    ];
+    const parseDecorators = (content) => {
+        const lines = String(content).split('\n');
+        const decorators = lines.filter(line => line.startsWith('@@@'));
+        return [decorators, lines.filter(line => !line.startsWith('@@@')).join('\n')];
+    };
+    const legacyHashInputs = [];
+    const optimizedHashInputs = [];
+    const hash = value => [...value].reduce((total, char) => (total * 31 + char.charCodeAt(0)) | 0, 0);
+
+    const legacy = legacyPrepare(entries, parseDecorators, (value) => {
+        legacyHashInputs.push(value);
+        return hash(value);
+    });
+    const optimized = prepareWorldInfoEntries(entries, parseDecorators, (value) => {
+        optimizedHashInputs.push(value);
+        return hash(value);
+    });
+
+    assert.deepEqual(optimizedHashInputs, legacyHashInputs);
+    assert.deepEqual(optimized, legacy);
+    assert.deepEqual(entries[0], { uid: 1, world: 'global', content: '@@@depth 2\nalpha', enabled: true, order: 10 });
+});

--- a/tests/world-info-token-batch-contract.test.mjs
+++ b/tests/world-info-token-batch-contract.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    canPrefetchWorldInfoTokenCount,
+    getWorldInfoTokenPrefetchBatch,
+} from '../src/scripts/world-info-token-prefetch.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('World info batches only exact safe token-count prefixes', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/world-info.js'), 'utf8');
+
+    assert.match(source, /getTokenCountAsync, getTokenPrefixCountsAsync/);
+    assert.match(source, /getWorldInfoTokenPrefetchBatch\(newEntries, entryIndex\)/);
+    assert.match(source, /getTokenPrefixCountsAsync\(batchBaseContent, batchSuffixes, undefined, remainingBudget\)/);
+    assert.match(source, /prefetchedTokenCounts\.has\(entry\)[\s\S]*getTokenCountAsync\(newContent\)/);
+});
+
+test('World info keeps probability, macro, budget, and activation ordering around token prefetch', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/world-info.js'), 'utf8');
+    const start = source.indexOf("console.debug('[WI] --- PROBABILITY CHECKS ---')");
+    const end = source.indexOf('const successfulNewEntries =', start);
+    const slice = source.slice(start, end);
+
+    const probabilityIndex = slice.indexOf('const success = verifyProbability()');
+    const substitutionIndex = slice.indexOf('entry.content = substituteParams(entry.content)');
+    const prefetchIndex = slice.indexOf('getWorldInfoTokenPrefetchBatch(newEntries, entryIndex)');
+    const budgetIndex = slice.indexOf('(textToScanTokens + newContentTokens) >= budget');
+    const activationIndex = slice.indexOf('allActivatedEntries.set');
+
+    assert.ok(probabilityIndex >= 0);
+    assert.ok(substitutionIndex > probabilityIndex);
+    assert.ok(prefetchIndex > substitutionIndex);
+    assert.ok(budgetIndex > prefetchIndex);
+    assert.ok(activationIndex > budgetIndex);
+    assert.match(slice, /const newContentTokens = entry\.ignoreBudget\s*\? 0/);
+    assert.match(slice, /if \(!entry\.ignoreBudget && \(textToScanTokens \+ newContentTokens\) >= budget\)/);
+});
+
+test('World info token prefetch rejects behavior-sensitive entries', () => {
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: '', ignoreBudget: false, useProbability: false }), true);
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: 'plain', ignoreBudget: true, useProbability: false }), false);
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: 'plain', ignoreBudget: false, useProbability: true, probability: 50 }), false);
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: 'plain', ignoreBudget: false, useProbability: true, probability: 100 }), true);
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: '{{user}}', ignoreBudget: false, useProbability: false }), false);
+    assert.equal(canPrefetchWorldInfoTokenCount({ content: '<USER>', ignoreBudget: false, useProbability: false }), false);
+});
+
+test('World info token prefetch keeps only the contiguous safe prefix in activation order', () => {
+    const entries = [
+        { uid: 1, content: 'first', ignoreBudget: false, useProbability: false },
+        { uid: 2, content: '', ignoreBudget: false, useProbability: false },
+        { uid: 3, content: '{{dynamic}}', ignoreBudget: false, useProbability: false },
+        { uid: 4, content: 'later', ignoreBudget: false, useProbability: false },
+    ];
+
+    const batch = getWorldInfoTokenPrefetchBatch(entries, 0);
+    assert.deepEqual(batch.entries, entries.slice(0, 2));
+    assert.deepEqual(batch.suffixes, ['first\n', '\n']);
+    assert.deepEqual(entries.map(entry => entry.uid), [1, 2, 3, 4]);
+
+    const laterBatch = getWorldInfoTokenPrefetchBatch(entries, 3);
+    assert.deepEqual(laterBatch.entries, [entries[3]]);
+    assert.deepEqual(laterBatch.suffixes, ['later\n']);
+});
+
+test('World info token prefetch keeps the native request bounded to 64 entries', () => {
+    const entries = Array.from({ length: 70 }, (_, index) => ({
+        uid: index,
+        content: `entry-${index}`,
+        ignoreBudget: false,
+        useProbability: false,
+    }));
+
+    const batch = getWorldInfoTokenPrefetchBatch(entries, 0);
+    assert.equal(batch.entries.length, 64);
+    assert.equal(batch.suffixes.length, 64);
+    assert.equal(batch.entries.at(-1), entries[63]);
+});
+
+test('Batch token counts preserve individual OpenAI wrapper semantics', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/tokenizers.js'), 'utf8');
+
+    assert.match(source, /export async function getTokenCountsAsync/);
+    assert.match(source, /countOpenAIMessageTokensBatchAsync\(messages\)/);
+    assert.match(source, /getOpenAITextTokenCount\(count\)/);
+    assert.match(source, /Promise\.all\(strings\.map\(text => getTokenCountAsync\(text, padding\)\)\)/);
+});
+
+test('Prefix token counts use compact native payload with an exact fallback', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/tokenizers.js'), 'utf8');
+
+    assert.match(source, /export async function getTokenPrefixCountsAsync/);
+    assert.match(source, /count-prefix-batch/);
+    assert.match(source, /const requestBody = JSON\.stringify\(\{ base, suffixes, stop_at: stopAt \}\)/);
+    assert.match(source, /countTokenPrefixesSingleFlight\(requestKey/);
+    assert.match(source, /data: requestBody/);
+    assert.match(source, /cacheState\.cache\[cacheKeys\[index\]\]/);
+    assert.match(source, /using exact batch fallback/);
+    assert.match(source, /return getTokenCountsAsync\(prefixes, padding\)/);
+});

--- a/tests/world-info-token-batch-contract.test.mjs
+++ b/tests/world-info-token-batch-contract.test.mjs
@@ -11,6 +11,78 @@ import {
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+function deterministicTokenCount(text) {
+    return String(text).length;
+}
+
+function countDeterministicPrefixes(base, suffixes, stopAt) {
+    let content = base;
+    const counts = [];
+
+    for (const suffix of suffixes) {
+        content += suffix;
+        const count = deterministicTokenCount(content);
+        counts.push(count);
+
+        if (Number.isFinite(stopAt) && count >= stopAt) {
+            while (counts.length < suffixes.length) {
+                counts.push(count);
+            }
+            break;
+        }
+    }
+
+    return counts;
+}
+
+function evaluateWorldInfoBudget(inputEntries, { budget, textToScanTokens = 0, prefetch }) {
+    const entries = inputEntries.map(entry => ({ ...entry }));
+    const activated = [];
+    const prefetchedTokenCounts = new Map();
+    const batchSizes = [];
+    let newContent = '';
+    let tokenBudgetOverflowed = false;
+    let ignoresBudget = entries.filter(entry => entry.ignoreBudget).length;
+
+    for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+        const entry = entries[entryIndex];
+        ignoresBudget -= entry.ignoreBudget ? 1 : 0;
+        if (tokenBudgetOverflowed && !entry.ignoreBudget) {
+            if (ignoresBudget > 0) {
+                continue;
+            }
+            break;
+        }
+
+        if (entry.useProbability && entry.probability !== 100 && entry.probabilityPass === false) {
+            continue;
+        }
+
+        entry.content = entry.resolvedContent ?? entry.content;
+        const batchBaseContent = newContent;
+        newContent += `${entry.content}\n`;
+
+        if (prefetch && canPrefetchWorldInfoTokenCount(entry) && !prefetchedTokenCounts.has(entry)) {
+            const batch = getWorldInfoTokenPrefetchBatch(entries, entryIndex);
+            const counts = countDeterministicPrefixes(batchBaseContent, batch.suffixes, budget - textToScanTokens);
+            batch.entries.forEach((batchEntry, index) => prefetchedTokenCounts.set(batchEntry, counts[index]));
+            batchSizes.push(batch.entries.length);
+        }
+
+        const newContentTokens = entry.ignoreBudget
+            ? 0
+            : prefetchedTokenCounts.get(entry) ?? deterministicTokenCount(newContent);
+        if (!entry.ignoreBudget && textToScanTokens + newContentTokens >= budget) {
+            tokenBudgetOverflowed = true;
+            continue;
+        }
+
+        activated.push(entry.uid);
+    }
+
+    return { activated, newContent, tokenBudgetOverflowed, batchSizes };
+}
+
 test('World info batches only exact safe token-count prefixes', async () => {
     const source = await readFile(path.join(REPO_ROOT, 'src/scripts/world-info.js'), 'utf8');
 
@@ -80,6 +152,70 @@ test('World info token prefetch keeps the native request bounded to 64 entries',
     assert.equal(batch.entries.length, 64);
     assert.equal(batch.suffixes.length, 64);
     assert.equal(batch.entries.at(-1), entries[63]);
+});
+
+test('World info token prefetch preserves budget decisions across sensitive entry boundaries', () => {
+    const fixtures = [
+        {
+            name: 'macro substitution, probability and ignore-budget entries',
+            budget: 200,
+            entries: [
+                { uid: 1, content: '{{user}}', resolvedContent: 'Alice', ignoreBudget: false, useProbability: false },
+                { uid: 2, content: 'plain', ignoreBudget: false, useProbability: false },
+                { uid: 3, content: 'rolled-out', ignoreBudget: false, useProbability: true, probability: 50, probabilityPass: false },
+                { uid: 4, content: 'guaranteed', ignoreBudget: false, useProbability: true, probability: 100 },
+                { uid: 5, content: 'free', ignoreBudget: true, useProbability: false },
+            ],
+        },
+        {
+            name: 'overflow skips paid entries but still activates a later ignore-budget entry',
+            budget: 10,
+            textToScanTokens: 2,
+            entries: [
+                { uid: 1, content: 'aa', ignoreBudget: false, useProbability: false },
+                { uid: 2, content: 'bbbb', ignoreBudget: false, useProbability: false },
+                { uid: 3, content: 'cccccc', ignoreBudget: false, useProbability: false },
+                { uid: 4, content: 'free', ignoreBudget: true, useProbability: false },
+                { uid: 5, content: 'after-free', ignoreBudget: false, useProbability: false },
+            ],
+        },
+    ];
+
+    for (const fixture of fixtures) {
+        const baseline = evaluateWorldInfoBudget(fixture.entries, { ...fixture, prefetch: false });
+        const optimized = evaluateWorldInfoBudget(fixture.entries, { ...fixture, prefetch: true });
+
+        assert.deepEqual(
+            {
+                activated: optimized.activated,
+                newContent: optimized.newContent,
+                tokenBudgetOverflowed: optimized.tokenBudgetOverflowed,
+            },
+            {
+                activated: baseline.activated,
+                newContent: baseline.newContent,
+                tokenBudgetOverflowed: baseline.tokenBudgetOverflowed,
+            },
+            fixture.name,
+        );
+        assert.ok(optimized.batchSizes.length > 0, `${fixture.name} should exercise prefix batching`);
+    }
+});
+
+test('World info token prefetch preserves activation order across the 64-entry batch boundary', () => {
+    const entries = Array.from({ length: 65 }, (_, index) => ({
+        uid: index + 1,
+        content: `entry-${index + 1}`,
+        ignoreBudget: false,
+        useProbability: false,
+    }));
+
+    const baseline = evaluateWorldInfoBudget(entries, { budget: 10_000, prefetch: false });
+    const optimized = evaluateWorldInfoBudget(entries, { budget: 10_000, prefetch: true });
+
+    assert.deepEqual(optimized.activated, baseline.activated);
+    assert.equal(optimized.newContent, baseline.newContent);
+    assert.deepEqual(optimized.batchSizes, [64, 1]);
 });
 
 test('Batch token counts preserve individual OpenAI wrapper semantics', async () => {


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。

## 变更说明 / Summary
### 问题

原本世界书按顺序检查激活条目时，会不断对持续增长的文本执行完整 Token 计数：

```text
条目 1
条目 1 + 2
条目 1 + 2 + 3
……
```

世界书达到约 5,000 条时，这种重复前缀扫描会形成近似二次增长，实机曾出现：

- 世界书 Token 阶段：`85.31–217.02 秒`
- 生成前界面长时间冻结
- Android 主线程卡顿、发热
- 多次 native tokenizer 调用进一步放大延迟

### 实际修改

#### 1. 增加累计前缀 Token 计数

新增 native command：

```text
count_openai_token_prefixes
```

一次传入：

```javascript
{
    base,
    suffixes,
    stop_at
}
```

Rust tokenizer 复用同一个 tokenizer，增量计算多个累计前缀，不再让 JS 为每个条目从头计算完整字符串。

主要文件：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\tokenizers.js`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src-tauri\crates\tt-adapter-tokenization\src\miktik_tokenizer_repository.rs`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src-tauri\crates\tt-ports\src\repositories\tokenizer_repository.rs`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src-tauri\crates\tt-application\src\services\tokenization_service.rs`

#### 2. 世界书安全批量预取

在世界书扫描过程中：

- 最多预取连续的 64 个安全条目；
- 批量得到每个累计前缀的精确 Token 数；
- 达到 budget 后让 Rust 提前停止后续无意义计算；
- 遇到动态宏、特殊递归或其他行为敏感条目时退回原有逐条精确路径。

主要文件：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\world-info.js`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\world-info-token-prefetch.js`

#### 3. Token 请求调度

增加：

- 相同在途请求 single-flight；
- 完整 DTO 作为去重 identity；
- prefix native 调用单并发；
- 请求完成后立即清除记录，不跨请求缓存结果。

主要文件：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\util\single-flight.js`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\tauri\main\kernel\invokes\invoke-policies.js`

#### 4. 世界书条目准备单次遍历

原本 decorator 解析、对象构造和 hash 生成分成多个 `.map()`；现在集中为一次遍历，同时保持旧 hash 输入和对象属性顺序。

文件：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\world-info-entry-prepare.js`

#### 5. Token 偏移语义集中

把 OpenAI 单消息 wrapper 的 `-1` 转换集中到公共函数，明确：

- Rust 返回原始 wrapper-inclusive 数量；
- JS 调用方看到的是正文 Token 数；
- `stop_at` 使用调用方可见的正文 Token 阈值。

文件：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\util\openai-token-count.js`

### 保持不变的行为

01 不改变：

- 世界书激活顺序；
- probability roll；
- 动态宏处理；
- recursion 行为；
- `ignoreBudget`；
- Token budget 命中结果；
- 最终世界书 prompt；
- 最终请求体结构；
- 上游新增的 lifecycle/session flush。

### 实测效果

| 指标 | 优化前 | 优化后 |
| --- | ---: | ---: |
| 世界书 Token 阶段 | 85.31–217.02 s | 真实生成平均约 199.3 ms |
| Prefix native 平均 | 124.2 ms | 26.1 ms |
| Prefix native P95 | 540 ms | 49 ms |
| 世界书 entries prepare | 平均 413.5 ms | 平均 200.6 ms |

世界书 Token 阶段保守来说下降至少 **98.9%**。