### PR TITLE
perf: prompt preview scheduling

### DIFF
--- a/src/scripts/PromptManager.js
+++ b/src/scripts/PromptManager.js
@@ -19,6 +19,7 @@ import {
     repairNullPromptManagerEntries,
     resolvePromptOrderFromDomIdentifiers,
 } from './prompt-manager-order-utils.js';
+import { createLatestTaskScheduler } from './util/latest-task-scheduler.js';
 
 function debouncePromise(func, delay) {
     let timeoutId;
@@ -425,6 +426,12 @@ class PromptManager {
 
         /** Debounced version of render */
         this.renderDebounced = debounce(this.render.bind(this), debounce_timeout.relaxed);
+
+        /** Coalesces prompt previews that arrive while a previous preview is still running. */
+        this.renderDryRunLatest = createLatestTaskScheduler(
+            () => this.#renderAfterTryGenerate(),
+            error => console.error('Prompt manager dry-run render failed', error),
+        );
     }
 
 
@@ -871,6 +878,46 @@ class PromptManager {
         document.getElementById(this.configuration.prefix + 'prompt_manager')?.closest('.scrollableInner')?.scrollTo(0, scrollPosition);
     }
 
+    async #renderPromptManagerUi() {
+        this.profileStart('render');
+        const scrollPosition = this.#getScrollPosition();
+        try {
+            await this.renderPromptManager();
+            await this.renderPromptManagerListItems();
+            this.makeDraggable();
+            this.#setScrollPosition(scrollPosition);
+        } finally {
+            this.profileEnd('render');
+        }
+    }
+
+    async #waitUntilGenerationIsIdle() {
+        try {
+            await waitUntilCondition(() => !is_send_press && !is_group_generating, 1024 * 1024, 100);
+            return true;
+        } catch {
+            console.log('Timeout while waiting for send press to be false');
+            return false;
+        }
+    }
+
+    async #renderAfterTryGenerate() {
+        if (!await this.#waitUntilGenerationIsIdle()) return;
+
+        this.profileStart('filling context');
+        try {
+            await this.tryGenerate();
+        } finally {
+            this.profileEnd('filling context');
+            await this.#renderPromptManagerUi();
+        }
+    }
+
+    async #renderWithoutTryGenerate() {
+        if (!await this.#waitUntilGenerationIsIdle()) return;
+        await this.#renderPromptManagerUi();
+    }
+
     /**
      * Main rendering function
      *
@@ -882,32 +929,13 @@ class PromptManager {
         if ('character' === this.configuration.promptOrder.strategy && null === this.activeCharacter) return;
         this.error = null;
 
-        waitUntilCondition(() => !is_send_press && !is_group_generating, 1024 * 1024, 100).then(async () => {
-            if (true === afterTryGenerate) {
-                // Executed during dry-run for determining context composition
-                this.profileStart('filling context');
-                this.tryGenerate().finally(async () => {
-                    this.profileEnd('filling context');
-                    this.profileStart('render');
-                    const scrollPosition = this.#getScrollPosition();
-                    await this.renderPromptManager();
-                    await this.renderPromptManagerListItems();
-                    this.makeDraggable();
-                    this.#setScrollPosition(scrollPosition);
-                    this.profileEnd('render');
-                });
-            } else {
-                // Executed during live communication
-                this.profileStart('render');
-                const scrollPosition = this.#getScrollPosition();
-                await this.renderPromptManager();
-                await this.renderPromptManagerListItems();
-                this.makeDraggable();
-                this.#setScrollPosition(scrollPosition);
-                this.profileEnd('render');
-            }
-        }).catch(() => {
-            console.log('Timeout while waiting for send press to be false');
+        if (afterTryGenerate === true) {
+            this.renderDryRunLatest();
+            return;
+        }
+
+        void this.#renderWithoutTryGenerate().catch(error => {
+            console.error('Prompt manager render failed', error);
         });
     }
 

--- a/src/scripts/PromptManager.js
+++ b/src/scripts/PromptManager.js
@@ -904,9 +904,13 @@ class PromptManager {
     async #renderAfterTryGenerate() {
         if (!await this.#waitUntilGenerationIsIdle()) return;
 
+        this.error = null;
         this.profileStart('filling context');
         try {
             await this.tryGenerate();
+        } catch (error) {
+            this.error = error instanceof Error ? error.message : String(error || t`Unknown error`);
+            throw error;
         } finally {
             this.profileEnd('filling context');
             await this.#renderPromptManagerUi();

--- a/src/scripts/util/latest-task-scheduler.js
+++ b/src/scripts/util/latest-task-scheduler.js
@@ -1,0 +1,37 @@
+/**
+ * Runs at most one task at a time and coalesces requests received while it is
+ * running into one final rerun against the latest state.
+ *
+ * @param {() => Promise<void>} task
+ * @param {(error: unknown) => void} [onError]
+ * @returns {() => void}
+ */
+export function createLatestTaskScheduler(task, onError = console.error) {
+    let running = false;
+    let pending = false;
+
+    async function drain() {
+        running = true;
+        try {
+            do {
+                pending = false;
+                try {
+                    await task();
+                } catch (error) {
+                    onError(error);
+                }
+            } while (pending);
+        } finally {
+            running = false;
+        }
+    }
+
+    return function scheduleLatest() {
+        if (running) {
+            pending = true;
+            return;
+        }
+
+        void drain();
+    };
+}

--- a/tests/latest-task-scheduler.test.mjs
+++ b/tests/latest-task-scheduler.test.mjs
@@ -85,6 +85,9 @@ test('task failures are reported without wedging future requests', async () => {
 
 test('PromptManager keeps dry-run rendering wired through the latest-task scheduler', async () => {
     const source = await readFile(path.join(REPO_ROOT, 'src/scripts/PromptManager.js'), 'utf8');
+    const dryRunStart = source.indexOf('    async #renderAfterTryGenerate() {');
+    const dryRunEnd = source.indexOf('    async #renderWithoutTryGenerate() {', dryRunStart);
+    const dryRunSource = source.slice(dryRunStart, dryRunEnd);
     const renderStart = source.indexOf('    render(afterTryGenerate = true) {');
     const renderEnd = source.indexOf('    updatePromptWithPromptEditForm(', renderStart);
     const renderSource = source.slice(renderStart, renderEnd);
@@ -94,6 +97,16 @@ test('PromptManager keeps dry-run rendering wired through the latest-task schedu
         source,
         /this\.renderDryRunLatest = createLatestTaskScheduler\(\s*\(\) => this\.#renderAfterTryGenerate\(\)/,
     );
+    assert.ok(dryRunStart >= 0 && dryRunEnd > dryRunStart);
+    const clearError = dryRunSource.indexOf('this.error = null;');
+    const tryGenerate = dryRunSource.indexOf('await this.tryGenerate();');
+    const exposeError = dryRunSource.indexOf('this.error = error instanceof Error');
+    const rethrowError = dryRunSource.indexOf('throw error;', exposeError);
+    const renderUi = dryRunSource.indexOf('await this.#renderPromptManagerUi();', rethrowError);
+    assert.ok(clearError >= 0 && clearError < tryGenerate);
+    assert.ok(tryGenerate < exposeError && exposeError < rethrowError);
+    assert.ok(rethrowError < renderUi);
+    assert.match(dryRunSource, /String\(error \|\| t`Unknown error`\)/);
     assert.ok(renderStart >= 0 && renderEnd > renderStart);
     assert.match(renderSource, /if \(afterTryGenerate === true\) \{\s*this\.renderDryRunLatest\(\);\s*return;/);
     assert.match(renderSource, /void this\.#renderWithoutTryGenerate\(\)\.catch/);

--- a/tests/latest-task-scheduler.test.mjs
+++ b/tests/latest-task-scheduler.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLatestTaskScheduler } from '../src/scripts/util/latest-task-scheduler.js';
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+test('requests during a running task coalesce into one latest rerun', async () => {
+    const runs = [];
+    const first = deferred();
+    const second = deferred();
+    const schedule = createLatestTaskScheduler(async () => {
+        const run = runs.length;
+        runs.push(run);
+        await [first, second][run].promise;
+    });
+
+    schedule();
+    schedule();
+    schedule();
+    assert.deepEqual(runs, [0]);
+
+    first.resolve();
+    await flushMicrotasks();
+    assert.deepEqual(runs, [0, 1]);
+
+    second.resolve();
+    await flushMicrotasks();
+    assert.deepEqual(runs, [0, 1]);
+});
+
+test('a request during the latest rerun schedules one more pass', async () => {
+    const gates = [deferred(), deferred(), deferred()];
+    let runCount = 0;
+    const schedule = createLatestTaskScheduler(async () => {
+        await gates[runCount++].promise;
+    });
+
+    schedule();
+    schedule();
+    gates[0].resolve();
+    await flushMicrotasks();
+    schedule();
+    gates[1].resolve();
+    await flushMicrotasks();
+
+    assert.equal(runCount, 3);
+    gates[2].resolve();
+    await flushMicrotasks();
+});
+
+test('task failures are reported without wedging future requests', async () => {
+    const errors = [];
+    let runCount = 0;
+    const schedule = createLatestTaskScheduler(async () => {
+        runCount += 1;
+        if (runCount === 1) throw new Error('expected failure');
+    }, error => errors.push(error));
+
+    schedule();
+    await flushMicrotasks();
+    schedule();
+    await flushMicrotasks();
+
+    assert.equal(runCount, 2);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0].message, /expected failure/);
+});

--- a/tests/latest-task-scheduler.test.mjs
+++ b/tests/latest-task-scheduler.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { createLatestTaskScheduler } from '../src/scripts/util/latest-task-scheduler.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function deferred() {
     let resolve;
@@ -76,4 +81,20 @@ test('task failures are reported without wedging future requests', async () => {
     assert.equal(runCount, 2);
     assert.equal(errors.length, 1);
     assert.match(errors[0].message, /expected failure/);
+});
+
+test('PromptManager keeps dry-run rendering wired through the latest-task scheduler', async () => {
+    const source = await readFile(path.join(REPO_ROOT, 'src/scripts/PromptManager.js'), 'utf8');
+    const renderStart = source.indexOf('    render(afterTryGenerate = true) {');
+    const renderEnd = source.indexOf('    updatePromptWithPromptEditForm(', renderStart);
+    const renderSource = source.slice(renderStart, renderEnd);
+
+    assert.match(source, /import \{ createLatestTaskScheduler \} from '\.\/util\/latest-task-scheduler\.js';/);
+    assert.match(
+        source,
+        /this\.renderDryRunLatest = createLatestTaskScheduler\(\s*\(\) => this\.#renderAfterTryGenerate\(\)/,
+    );
+    assert.ok(renderStart >= 0 && renderEnd > renderStart);
+    assert.match(renderSource, /if \(afterTryGenerate === true\) \{\s*this\.renderDryRunLatest\(\);\s*return;/);
+    assert.match(renderSource, /void this\.#renderWithoutTryGenerate\(\)\.catch/);
 });


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。

## 变更说明 / Summary

### 问题

PromptManager 的许多事件会触发完整 dry run，例如：

- 世界书设置变化；
- 聊天加载或消息编辑；
- 模型和预设变化；
- Prompt Manager 操作；
- slash command。

每个 dry run 都会执行一遍完整的生成前准备，包括世界书扫描、Token 计数和 prompt 组装。

原实现允许多个 dry run 同时运行，导致：

```text
dry run A ───────────────
       dry run B ───────────────
              dry run C ───────────────
```

这会重复消耗 CPU，并放大 01 中的世界书热点。

### 实际修改

02 相对 01 **只修改了三个文件**：

- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\PromptManager.js`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\src\scripts\util\latest-task-scheduler.js`
- `D:\Codex-workdir\tauritavern\TauriTavern-exynos\tests\latest-task-scheduler.test.mjs`

#### Latest-wins 调度

新的调度规则：

1. 没有任务运行时，立即执行 dry run；
2. dry run 运行期间出现新请求，只记录一次 pending；
3. 当前任务完成后，再执行一次最新 dry run；
4. 不允许两个 dry run 并发；
5. 如果最新一轮执行期间又出现请求，可以继续追加下一轮；
6. 单次任务失败不会让调度器永久卡死。

效果类似：

```text
dry run A ───────────────
多个新请求：合并为 pending
                            dry run latest ─────────
```

#### 没有更改：

- `Generate('normal', {}, true)` dry run 路径；
- 世界书扫描逻辑；
- Prompt Manager 最终显示内容；
- 正式生成流程；
- API 请求体；
- 网络请求；
- 插件事件顺序。

### 实测结果

性能样本中曾观测到多个完整 prompt dry run 重叠。加入 latest-wins 后：

```text
13 次 dry run 的实际执行区间重叠数：0
```

它主要解决的是 **重复并发放大**，并不保证减少所有顺序执行的 dry run。

---

也就是：

```text
01：一次世界书扫描不要再花几分钟
02：不要同时启动多次完整世界书扫描
```

#### 请按照分支顺序01,02进行合并
