### PR TITLE
fix(test): make tauri-ready contract tests deterministic across platforms

### DIFF
--- a/tests/tauri-ready-contract.test.mjs
+++ b/tests/tauri-ready-contract.test.mjs
@@ -18,10 +18,19 @@ function installTauriWindow(readyPromise) {
     };
 }
 
-function rejectSoon(error) {
-    return new Promise((_, reject) => {
-        setTimeout(() => reject(error), 0);
+// Returns a controllable deferred rejection. Rejecting via a bare
+// setTimeout(0) races the dynamic import() in the tests: on slower
+// filesystems (e.g. Windows) the promise rejects before any handler is
+// attached, and the test runner fails the test on the unhandled rejection.
+function createDeferredRejection() {
+    let rejectPromise;
+    const promise = new Promise((_, reject) => {
+        rejectPromise = reject;
     });
+    return {
+        promise,
+        reject: (error) => rejectPromise(error),
+    };
 }
 
 function cleanupGlobals() {
@@ -29,25 +38,31 @@ function cleanupGlobals() {
 }
 
 test('waitForTauriMainReady preserves default fallback behavior', async () => {
-    installTauriWindow(rejectSoon(new Error('backend failed')));
+    const deferred = createDeferredRejection();
+    installTauriWindow(deferred.promise);
 
     try {
         const { waitForTauriMainReady } = await importFreshReady();
 
-        await assert.doesNotReject(waitForTauriMainReady());
+        const waiting = waitForTauriMainReady();
+        deferred.reject(new Error('backend failed'));
+        await assert.doesNotReject(waiting);
     } finally {
         cleanupGlobals();
     }
 });
 
 test('waitForTauriMainReady can fail fast for the main startup path', async () => {
-    installTauriWindow(rejectSoon(new Error('backend failed')));
+    const deferred = createDeferredRejection();
+    installTauriWindow(deferred.promise);
 
     try {
         const { waitForTauriMainReady } = await importFreshReady();
 
+        const waiting = waitForTauriMainReady({ failFast: true });
+        deferred.reject(new Error('backend failed'));
         await assert.rejects(
-            waitForTauriMainReady({ failFast: true }),
+            waiting,
             /backend failed/,
         );
     } finally {


### PR DESCRIPTION
> ⚠️ **提交者个人总结（提交前请用自己的话填写，勿删除本行提醒）**：
> 【跑环境测试的时候发现一个测试里的小bug，让win环境存在竞态，过不了，随手修了】

## 问题

`tests/tauri-ready-contract.test.mjs` 中的两个 `waitForTauriMainReady` 测试存在时序竞争：

测试在 setup 阶段用 `setTimeout(() => reject(error), 0)` 触发后端就绪 promise 的拒绝，随后才 `await import(...)` 并调用 `waitForTauriMainReady()` 挂载 catch。当动态 import 耗时超过定时器（在 Windows 上可 100% 复现），promise 会在没有任何 handler 的情况下先拒绝：

1. Node 将其判定为 unhandled rejection，输出 `PromiseRejectionHandledWarning: Promise rejection was handled asynchronously`；
2. node test runner 将测试期间的未处理拒绝记为测试失败 —— 即使被测代码稍后正确地 catch 了它。

结果是这两个测试在 Windows 上确定性失败（`pnpm run check` 基线 2 fail），在 Linux CI 上依赖 import 快于 1ms 定时器的时序运气才能通过。被测的 `src/scripts/extensions/runtime/tauri-ready.js` 产品逻辑本身没有问题。

## 修改内容

仅修改 `tests/tauri-ready-contract.test.mjs`：

- 将 `rejectSoon()`（定时器触发）替换为 `createDeferredRejection()`（可控 deferred）；
- 两个测试都改为：先调用 `waitForTauriMainReady()` 挂载 handler，再手动触发 `deferred.reject()`，最后断言。

时序从「依赖机器速度」变为「必然顺序」，测试在任何平台/负载下行为一致。无产品代码改动。

## 修改思路

竞争的本质是「拒绝触发时机不受控」。与其调大定时器（仍是概率性修复），不如让测试显式控制拒绝发生的时刻——在 handler 挂载之后触发，这既消除了竞争，也更精确地表达了被测契约：*fallback 路径应当处理一个被拒绝的 ready promise*。

## 验证

- 修复前（本机 Windows，Node 22.17 / 23.11）：该文件 0 pass / 2 fail，连跑 5 次稳定复现；
- 修复后：该文件 2 pass / 0 fail；`pnpm run check` 全量 843 tests / 840 pass / 0 fail / 3 skipped。