### PR TITLE
Improve stable release artifacts and Linux repository publishing

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -114,6 +116,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
 
       - name: Check ${{ matrix.name }} Rust target
         run: >-

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -87,20 +87,37 @@ jobs:
         include:
           - platform: windows-latest
             target_args: ""
+            artifact_prefix: ""
             portable: true
             portable_name: windows-x64
+          - platform: windows-latest
+            target_args: --debug --bundles nsis
+            artifact_prefix: debug-
+            portable: false
           - platform: macos-latest
             target_args: --target x86_64-apple-darwin
+            artifact_prefix: ""
+            portable: false
+          - platform: macos-latest
+            target_args: --target x86_64-apple-darwin --debug --bundles dmg
+            artifact_prefix: debug-
             portable: false
           - platform: macos-latest
             target_args: --target aarch64-apple-darwin
+            artifact_prefix: ""
+            portable: false
+          - platform: macos-latest
+            target_args: --target aarch64-apple-darwin --debug --bundles dmg
+            artifact_prefix: debug-
             portable: false
           - platform: ubuntu-22.04
             target_args: --bundles appimage,deb,rpm
+            artifact_prefix: ""
             portable: true
             portable_name: linux-x64
           - platform: ubuntu-22.04-arm
             target_args: --bundles deb,rpm
+            artifact_prefix: ""
             portable: true
             portable_name: linux-arm64
 
@@ -166,7 +183,7 @@ jobs:
           uploadWorkflowArtifacts: true
           uploadUpdaterJson: false
           uploadUpdaterSignatures: false
-          workflowArtifactNamePattern: 'TauriTavern-${{ needs.prepare.outputs.version }}-[platform]-[arch]-[bundle]'
+          workflowArtifactNamePattern: 'TauriTavern-${{ needs.prepare.outputs.version }}-${{ matrix.artifact_prefix }}[platform]-[arch]-[bundle]'
 
       - name: Build portable binary
         if: matrix.portable
@@ -441,7 +458,7 @@ jobs:
           path: dist
 
       - name: Validate and collect release assets
-        run: node source/scripts/ci/collect-release-assets.mjs dist release-assets "$ASSET_PREFIX"
+        run: node source/scripts/ci/collect-release-assets.mjs dist release-assets "$ASSET_PREFIX" --require-debug
 
       - name: Upload assets without changing release notes
         shell: bash

--- a/distribution/flatpak/publish.sh
+++ b/distribution/flatpak/publish.sh
@@ -96,6 +96,11 @@ else
     ostree init --repo="$repository_dir" --mode=archive-z2
 fi
 
+# Object stores preserve files, not empty directories. OSTree creates this
+# directory during init, and Flatpak requires it when listing refs for static
+# delta generation on subsequent publishes.
+mkdir -p "$repository_dir/refs/remotes"
+
 release_subject="TauriTavern ${RELEASE_VERSION}"
 release_tag_line="Release tag: ${RELEASE_TAG}"
 source_commit_line="Source commit: ${RELEASE_COMMIT}"

--- a/docs/CurrentState/LinuxRepository.md
+++ b/docs/CurrentState/LinuxRepository.md
@@ -167,6 +167,9 @@ nix run github:Darkatse/TauriTavern
 nix build github:Darkatse/TauriTavern
 ```
 
+Rust 依赖直接由 `src-tauri/Cargo.lock` 中的版本和 checksum 固定，不额外维护容易与 lockfile 漂移的整体 `cargoHash`。如果以后加入 Git 来源的 crate，需要在 `cargoLock.outputHashes` 中显式固定相应源码。
+`pnpmDeps` 仍是一个整体的离线依赖仓库；`pnpm-lock.yaml` 变化后，需要按 Nix 构建报告的实际值手动更新其固定哈希。
+
 通过安装脚本加入当前用户 profile：
 
 ```sh
@@ -246,7 +249,7 @@ Canary CI 自动读取 GitHub 最新正式 Release 作为版本基线。以 2.1.
 2. 私钥不进入 Git、R2、构建产物或日志。日常 OpenPGP 发布环境只持有签名子密钥。
 3. 版本化负载和普通索引先上传，各仓库的签名指针最后更新；公钥独立维护，清单在发布完成后更新。
 4. 可变入口使用 `Cache-Control: no-cache`；版本化软件包和哈希对象使用 `public, max-age=31536000, immutable`。
-5. Nix cache 只接收从确定 Git revision 构建并由专用 Nix key 签名的 runtime closure、Cargo vendor 和 pnpm dependency paths。
+5. Nix cache 只接收从确定 Git revision 构建并由专用 Nix key 签名的 runtime closure、Cargo lockfile 依赖闭包和 pnpm dependency paths。
 6. Stable tag 发布后不移动。Canary Nix 使用显式 `canary` 输出和提交身份，不替代默认 Stable 包。
 7. 每次发布后从公开域名验证签名、索引和实际软件下载，不只验证 R2 私有端点。
 8. OpenPGP 签名子密钥应在 2029-07-24 前完成轮换。

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -29,7 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri/crates/tauritavern";
-  cargoHash = "sha256-liGQG8h4DsjCuQb7T//sC0MuJYC1UHyK7wrRkwh+Mlg=";
+  cargoLock = {
+    lockFile = ../src-tauri/Cargo.lock;
+  };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -39,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-QwzuJvkenRRdlH5o1A5vXCyUFif98NNHrRZyW0+eIcU=";
+    hash = "sha256-aDxsMBQcMWYJl4FPTo+cReYnkqbiMuSvKRzslwmkGVM=";
   };
 
   nativeBuildInputs = [

--- a/scripts/ci/collect-release-assets.mjs
+++ b/scripts/ci/collect-release-assets.mjs
@@ -12,6 +12,9 @@ const RELEASE_ASSETS = new Map([
     ['android-arm64-apk', ['android-arm64-v8a.apk', '.apk']],
     ['darwin-aarch64-dmg', ['macos-arm64.dmg', '.dmg']],
     ['darwin-x64-dmg', ['macos-x64.dmg', '.dmg']],
+    ['debug-darwin-aarch64-dmg', ['macos-arm64-DEBUG.dmg', '.dmg']],
+    ['debug-darwin-x64-dmg', ['macos-x64-DEBUG.dmg', '.dmg']],
+    ['debug-windows-x64-nsis', ['windows-x64-setup-DEBUG.exe', '.exe']],
     ['ios-arm64-ipa', ['ios-arm64.ipa', '.ipa']],
     ['ios-arm64-TestFlight-ipa', ['ios-arm64-TestFlight.ipa', '.ipa']],
     ['linux-aarch64-rpm', ['linux-arm64.rpm', '.rpm']],
@@ -29,6 +32,14 @@ const RELEASE_ASSETS = new Map([
 const IGNORED_ARTIFACTS = new Set([
     'darwin-aarch64-app',
     'darwin-x64-app',
+    'debug-darwin-aarch64-app',
+    'debug-darwin-x64-app',
+]);
+
+const DEBUG_ARTIFACTS = new Set([
+    'debug-darwin-aarch64-dmg',
+    'debug-darwin-x64-dmg',
+    'debug-windows-x64-nsis',
 ]);
 
 async function listFiles(directory) {
@@ -66,6 +77,7 @@ export async function collectReleaseAssets({
     inputDirectory,
     outputDirectory,
     artifactPrefix,
+    requireDebug = false,
 }) {
     validatePrefix(artifactPrefix);
 
@@ -109,7 +121,8 @@ export async function collectReleaseAssets({
         });
     }
 
-    const missing = [...RELEASE_ASSETS.keys()].filter((suffix) => !found.has(suffix));
+    const missing = [...RELEASE_ASSETS.keys()]
+        .filter((suffix) => !found.has(suffix) && (requireDebug || !DEBUG_ARTIFACTS.has(suffix)));
     if (missing.length > 0) {
         throw new Error(`Missing workflow artifacts: ${missing.map((suffix) => artifactPrefix + suffix).join(', ')}`);
     }
@@ -132,10 +145,17 @@ export async function collectReleaseAssets({
 }
 
 async function main() {
-    const [inputDirectory, outputDirectory, artifactPrefix] = process.argv.slice(2);
-    if (!inputDirectory || !outputDirectory || !artifactPrefix || process.argv.length !== 5) {
+    const [inputDirectory, outputDirectory, artifactPrefix, option] = process.argv.slice(2);
+    if (
+        !inputDirectory
+        || !outputDirectory
+        || !artifactPrefix
+        || (option !== undefined && option !== '--require-debug')
+        || process.argv.length < 5
+        || process.argv.length > 6
+    ) {
         throw new Error(
-            'Usage: collect-release-assets.mjs <workflow-artifacts-dir> <release-assets-dir> <artifact-prefix>',
+            'Usage: collect-release-assets.mjs <workflow-artifacts-dir> <release-assets-dir> <artifact-prefix> [--require-debug]',
         );
     }
 
@@ -143,6 +163,7 @@ async function main() {
         inputDirectory: resolve(inputDirectory),
         outputDirectory: resolve(outputDirectory),
         artifactPrefix,
+        requireDebug: option === '--require-debug',
     });
     process.stdout.write(`${assets.join('\n')}\n`);
 }

--- a/tests/ci-release-assets.test.mjs
+++ b/tests/ci-release-assets.test.mjs
@@ -13,6 +13,11 @@ const ARTIFACTS = new Map([
     ['darwin-aarch64-dmg', 'TauriTavern_aarch64.dmg'],
     ['darwin-x64-app', 'TauriTavern.app/Contents/MacOS/TauriTavern'],
     ['darwin-x64-dmg', 'TauriTavern_x64.dmg'],
+    ['debug-darwin-aarch64-app', 'TauriTavern.app/Contents/MacOS/TauriTavern'],
+    ['debug-darwin-aarch64-dmg', 'TauriTavern_aarch64.dmg'],
+    ['debug-darwin-x64-app', 'TauriTavern.app/Contents/MacOS/TauriTavern'],
+    ['debug-darwin-x64-dmg', 'TauriTavern_x64.dmg'],
+    ['debug-windows-x64-nsis', 'TauriTavern_2.2.0_x64-setup.exe'],
     ['ios-arm64-ipa', 'TauriTavern.ipa'],
     ['ios-arm64-TestFlight-ipa', 'TauriTavern.ipa'],
     ['linux-aarch64-rpm', 'TauriTavern-2.2.0-1.aarch64.rpm'],
@@ -39,16 +44,20 @@ const EXPECTED_RELEASE_ASSETS = [
     'TauriTavern-2.2.0-linux-x64.AppImage',
     'TauriTavern-2.2.0-linux-x64.deb',
     'TauriTavern-2.2.0-linux-x64.rpm',
+    'TauriTavern-2.2.0-macos-arm64-DEBUG.dmg',
     'TauriTavern-2.2.0-macos-arm64.dmg',
+    'TauriTavern-2.2.0-macos-x64-DEBUG.dmg',
     'TauriTavern-2.2.0-macos-x64.dmg',
     'TauriTavern-2.2.0-windows-x64-portable.exe',
+    'TauriTavern-2.2.0-windows-x64-setup-DEBUG.exe',
     'TauriTavern-2.2.0-windows-x64-setup.exe',
     'TauriTavern-2.2.0-windows-x64.msi',
 ].sort();
 
-async function createArtifacts(root, prefix, omittedSuffix = null) {
+async function createArtifacts(root, prefix, omittedSuffixes = []) {
+    const omitted = new Set(Array.isArray(omittedSuffixes) ? omittedSuffixes : [omittedSuffixes]);
     for (const [suffix, relativeFile] of ARTIFACTS) {
-        if (suffix === omittedSuffix) {
+        if (omitted.has(suffix)) {
             continue;
         }
         const file = join(root, `${prefix}${suffix}`, relativeFile);
@@ -57,7 +66,7 @@ async function createArtifacts(root, prefix, omittedSuffix = null) {
     }
 }
 
-test('collectReleaseAssets publishes the shared Stable and Canary naming contract', async (t) => {
+test('collectReleaseAssets publishes the complete Stable naming contract', async (t) => {
     const root = await mkdtemp(join(tmpdir(), 'tauritavern-release-assets-'));
     t.after(() => rm(root, { recursive: true, force: true }));
 
@@ -70,6 +79,7 @@ test('collectReleaseAssets publishes the shared Stable and Canary naming contrac
         inputDirectory,
         outputDirectory,
         artifactPrefix,
+        requireDebug: true,
     });
 
     assert.deepEqual(assets.map((asset) => basename(asset)), EXPECTED_RELEASE_ASSETS);
@@ -83,7 +93,14 @@ test('collectReleaseAssets fails before publishing an incomplete release set', a
     const inputDirectory = join(root, 'dist');
     const outputDirectory = join(root, 'release-assets');
     const artifactPrefix = 'TauriTavern-20260726-canary-';
-    await createArtifacts(inputDirectory, artifactPrefix, 'android-arm64-apk');
+    await createArtifacts(inputDirectory, artifactPrefix, [
+        'android-arm64-apk',
+        'debug-darwin-aarch64-app',
+        'debug-darwin-aarch64-dmg',
+        'debug-darwin-x64-app',
+        'debug-darwin-x64-dmg',
+        'debug-windows-x64-nsis',
+    ]);
 
     await assert.rejects(
         collectReleaseAssets({
@@ -91,7 +108,22 @@ test('collectReleaseAssets fails before publishing an incomplete release set', a
             outputDirectory,
             artifactPrefix,
         }),
-        /Missing workflow artifacts: TauriTavern-20260726-canary-android-arm64-apk/,
+        { message: 'Missing workflow artifacts: TauriTavern-20260726-canary-android-arm64-apk' },
     );
     await assert.rejects(readdir(outputDirectory), { code: 'ENOENT' });
+});
+
+test('collectReleaseAssets requires every Stable debug artifact', async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'tauritavern-release-assets-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+
+    const inputDirectory = join(root, 'dist');
+    const outputDirectory = join(root, 'release-assets');
+    const artifactPrefix = 'TauriTavern-2.2.0-';
+    await createArtifacts(inputDirectory, artifactPrefix, 'debug-windows-x64-nsis');
+
+    await assert.rejects(
+        collectReleaseAssets({ inputDirectory, outputDirectory, artifactPrefix, requireDebug: true }),
+        /Missing workflow artifacts: TauriTavern-2\.2\.0-debug-windows-x64-nsis/,
+    );
 });

--- a/tests/linux-installer.test.mjs
+++ b/tests/linux-installer.test.mjs
@@ -20,6 +20,15 @@ function osReleaseFile(contents) {
     return path;
 }
 
+function shellPath(path, platform = process.platform) {
+    if (platform !== 'win32') {
+        return path;
+    }
+
+    const normalized = path.replaceAll('\\', '/');
+    return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
+}
+
 function runDryRun({
     shell = 'sh',
     osRelease,
@@ -47,7 +56,7 @@ function runDryRun({
                 ...process.env,
                 TAURITAVERN_TEST_ARCHITECTURE: architecture,
                 TAURITAVERN_TEST_KERNEL: 'Linux',
-                TAURITAVERN_TEST_OS_RELEASE: osReleasePath ?? osReleaseFile(osRelease),
+                TAURITAVERN_TEST_OS_RELEASE: shellPath(osReleasePath ?? osReleaseFile(osRelease)),
             },
         },
     );
@@ -65,6 +74,14 @@ function runDryRun({
 test('Linux installer keeps all side effects behind the final main call', () => {
     const lastLine = installerSource.trimEnd().split('\n').at(-1);
     assert.equal(lastLine, 'main "$@"');
+});
+
+test('Linux installer test paths use the shell filesystem namespace', () => {
+    assert.equal(
+        shellPath('C:\\Users\\runner\\AppData\\Local\\Temp\\os-release', 'win32'),
+        '/c/Users/runner/AppData/Local/Temp/os-release',
+    );
+    assert.equal(shellPath('/tmp/os-release', 'linux'), '/tmp/os-release');
 });
 
 test('Linux installer is syntactically valid in available common shells', () => {
@@ -94,7 +111,7 @@ test('Linux installer supports piped execution through common shells', () => {
                     ...process.env,
                     TAURITAVERN_TEST_ARCHITECTURE: 'amd64',
                     TAURITAVERN_TEST_KERNEL: 'Linux',
-                    TAURITAVERN_TEST_OS_RELEASE: release,
+                    TAURITAVERN_TEST_OS_RELEASE: shellPath(release),
                 },
             },
         );

--- a/tests/stable-release-workflow.test.mjs
+++ b/tests/stable-release-workflow.test.mjs
@@ -7,6 +7,8 @@ const workflowPath = '.github/workflows/stable-release.yml';
 const workflowSource = readFileSync(workflowPath, 'utf8');
 const workflow = YAML.parse(workflowSource);
 const flatpakPublisherSource = readFileSync('distribution/flatpak/publish.sh', 'utf8');
+const nixPackageSource = readFileSync('nix/package.nix', 'utf8');
+const cargoLockSource = readFileSync('src-tauri/Cargo.lock', 'utf8');
 
 test('stable release workflow starts from a published release or an explicit tag', () => {
     assert.deepEqual(workflow.on.release.types, ['published']);
@@ -66,6 +68,12 @@ test('stable Nix publication includes reusable project dependencies', () => {
     assert.match(workflowSource, /tauritavern\.cargoDeps\.outPath/);
     assert.match(workflowSource, /tauritavern\.pnpmDeps\.outPath/);
     assert.match(workflowSource, /NIX_CACHE_URL: https:\/\/nix-cache\.tauritavern\.com/);
+});
+
+test('Nix derives Rust dependencies directly from Cargo.lock', () => {
+    assert.match(nixPackageSource, /cargoLock\s*=\s*\{\s*lockFile = \.\.\/src-tauri\/Cargo\.lock;/);
+    assert.doesNotMatch(nixPackageSource, /\bcargoHash\s*=/);
+    assert.doesNotMatch(cargoLockSource, /^source = "git\+/m);
 });
 
 test('stable Flatpak build and publication keep signing isolated', () => {

--- a/tests/stable-release-workflow.test.mjs
+++ b/tests/stable-release-workflow.test.mjs
@@ -18,6 +18,26 @@ test('stable release workflow preserves manually written release notes', () => {
     assert.match(workflowSource, /Upload assets without changing release notes/);
 });
 
+test('stable release builds Windows and macOS debug installers in parallel', () => {
+    const debugBuilds = workflow.jobs.desktop.strategy.matrix.include
+        .filter((entry) => entry.artifact_prefix === 'debug-')
+        .map(({ platform, target_args: targetArgs, portable }) => ({ platform, targetArgs, portable }));
+
+    assert.deepEqual(debugBuilds, [
+        { platform: 'windows-latest', targetArgs: '--debug --bundles nsis', portable: false },
+        {
+            platform: 'macos-latest',
+            targetArgs: '--target x86_64-apple-darwin --debug --bundles dmg',
+            portable: false,
+        },
+        {
+            platform: 'macos-latest',
+            targetArgs: '--target aarch64-apple-darwin --debug --bundles dmg',
+            portable: false,
+        },
+    ]);
+});
+
 test('stable release workflow publishes release assets before optional repositories', () => {
     assert.deepEqual(workflow.jobs['publish-release'].needs, ['prepare', 'desktop', 'mobile']);
 

--- a/tests/stable-release-workflow.test.mjs
+++ b/tests/stable-release-workflow.test.mjs
@@ -95,3 +95,12 @@ test('stable Flatpak build and publication keep signing isolated', () => {
     assert.match(flatpakPublisherSource, /summary\.sig/);
     assert.match(flatpakPublisherSource, /public, max-age=31536000, immutable/);
 });
+
+test('Flatpak publication restores OSTree ref layout lost by object storage', () => {
+    const restoreRefs = flatpakPublisherSource.indexOf('mkdir -p "$repository_dir/refs/remotes"');
+    const updateRepository = flatpakPublisherSource.indexOf('flatpak build-update-repo');
+
+    assert.notEqual(restoreRefs, -1);
+    assert.notEqual(updateRepository, -1);
+    assert.ok(restoreRefs < updateRepository);
+});


### PR DESCRIPTION
## Summary

- publish Windows and macOS debug installers alongside stable release artifacts
- derive Nix Rust dependencies directly from `Cargo.lock` and use the verified pnpm dependency hash
- restore the OSTree `refs/remotes` layout before subsequent Flatpak repository updates
- normalize Windows shell paths in the Linux installer test harness
- cache the actual `src-tauri/target` workspace in PR desktop and mobile jobs
- document the remaining manual pnpm hash maintenance boundary

## Why

The Nix package used an aggregate Cargo hash that could drift from the lockfile, while Flatpak repository updates could fail after an R2 round trip because object storage does not preserve empty directories. The Windows test harness passed a native path to Dash, and PR Rust caching watched the repository-root `target` instead of the real `src-tauri/target`. The stable release also needed explicit debug desktop artifacts.

## Impact

Stable releases keep their existing user-written notes and non-blocking repository publication model. Nix dependency resolution now follows the committed Cargo lockfile, repeated Flatpak publication can regenerate static deltas correctly, Windows validates piped installer execution, and future PR checks can reuse Rust build artifacts.

## Validation

- PR quality gate run `30520019109`: Linux, Windows, macOS, Android, and iOS passed
- `node --test tests/release-version.test.mjs tests/stable-release-workflow.test.mjs`
- `node --test tests/linux-installer.test.mjs`
- `bash -n distribution/flatpak/publish.sh`
- workflow YAML and Rust workspace cache declarations parsed locally
- `git diff --check`
- real Nix pnpm fixed-output hash verification completed locally