### PR TITLE
fix(skill-manager): 修复导入 Skill 后 UI 卡死、按钮变灰无法点击的问题

### DIFF
--- a/src/scripts/extensions/agent-system/src/skill-manager/panel-app.js
+++ b/src/scripts/extensions/agent-system/src/skill-manager/panel-app.js
@@ -737,18 +737,23 @@ export function createSkillManagerPanelRoot() {
                     sectionId: section.id,
                 };
                 const api = requireSkillApi();
-                for (const item of items) {
+                // Mutate items through the reactive proxy (this.importDraft.items)
+                // so Vue 3 re-evaluates computed properties like importBusy.
+                // Writing to the raw `items` references bypasses reactivity and
+                // leaves :disabled="importBusy" buttons permanently greyed out.
+                for (let index = 0; index < items.length; index += 1) {
                     try {
-                        item.preview = await api.previewImport({
-                            input: item.input,
+                        const preview = await api.previewImport({
+                            input: items[index].input,
                             targetScope: section.scope,
                         });
+                        this.importDraft.items[index].preview = preview;
                     } catch (error) {
                         if (items.length === 1) {
                             this.importDraft = emptyImportDraft();
                             throw error;
                         }
-                        item.error = errorText(error);
+                        this.importDraft.items[index].error = errorText(error);
                         console.error('[AgentSystem:SkillManager] Failed to preview Skill import:', error);
                     }
                 }

--- a/src/scripts/extensions/agent-system/src/skill-manager/panel-app.js
+++ b/src/scripts/extensions/agent-system/src/skill-manager/panel-app.js
@@ -697,10 +697,11 @@ export function createSkillManagerPanelRoot() {
                 return '';
             },
             async clearImportDraft() {
-                if (this.importDraft.items.length > 0) {
+                const hasItems = this.importDraft.items.length > 0;
+                this.importDraft = emptyImportDraft();
+                if (hasItems) {
                     await requireSkillApi().discardPickedImport();
                 }
-                this.importDraft = emptyImportDraft();
             },
             async pickAndPreviewImport(section, importKind = 'archive') {
                 if (!section.available) {
@@ -730,30 +731,32 @@ export function createSkillManagerPanelRoot() {
                 if (!section.available) {
                     throw new Error(this.sectionUnavailableText(section));
                 }
-                const items = inputs.map(createImportItem);
                 this.importDraft = {
                     ...emptyImportDraft(),
-                    items,
+                    items: inputs.map(createImportItem),
                     sectionId: section.id,
                 };
+                const draft = this.importDraft;
                 const api = requireSkillApi();
-                // Mutate items through the reactive proxy (this.importDraft.items)
-                // so Vue 3 re-evaluates computed properties like importBusy.
-                // Writing to the raw `items` references bypasses reactivity and
-                // leaves :disabled="importBusy" buttons permanently greyed out.
-                for (let index = 0; index < items.length; index += 1) {
+                for (const item of draft.items) {
                     try {
                         const preview = await api.previewImport({
-                            input: items[index].input,
+                            input: item.input,
                             targetScope: section.scope,
                         });
-                        this.importDraft.items[index].preview = preview;
+                        if (this.importDraft !== draft) {
+                            return;
+                        }
+                        item.preview = preview;
                     } catch (error) {
-                        if (items.length === 1) {
+                        if (this.importDraft !== draft) {
+                            return;
+                        }
+                        if (draft.items.length === 1) {
                             this.importDraft = emptyImportDraft();
                             throw error;
                         }
-                        this.importDraft.items[index].error = errorText(error);
+                        item.error = errorText(error);
                         console.error('[AgentSystem:SkillManager] Failed to preview Skill import:', error);
                     }
                 }

--- a/tests/agent-frontend-contract.test.mjs
+++ b/tests/agent-frontend-contract.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { computed, reactive } from 'vue';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -2826,6 +2827,68 @@ test('Agent System profile panel no longer owns legacy Skill management UI', asy
     assert.match(skillExtensionStyles, /\.ttas-skill-import-directory-hint\.visible\s*\{\s*visibility:\s*visible;/);
     assert.doesNotMatch(skillFileViewerSource, /showModal/);
     assert.doesNotMatch(skillFileViewerSource, /createApp/);
+});
+
+test('Skill Manager keeps reactive preview results scoped to the active import draft', async () => {
+    const pendingPreviews = new Map();
+    installWindow({
+        skill: {
+            previewImport({ input }) {
+                return new Promise((resolve, reject) => {
+                    pendingPreviews.set(input.path, { resolve, reject });
+                });
+            },
+            async discardPickedImport() {},
+        },
+    });
+
+    const { createSkillManagerPanelRoot } = await importFresh(
+        'src/scripts/extensions/agent-system/src/skill-manager/panel-app.js',
+    );
+    const options = createSkillManagerPanelRoot();
+    const vm = reactive(options.data());
+    for (const [name, method] of Object.entries(options.methods)) {
+        vm[name] = method.bind(vm);
+    }
+    const importBusy = computed(options.computed.importBusy.bind(vm));
+    const section = { id: 'global', available: true, scope: { kind: 'global' } };
+    const input = (name) => ({ kind: 'archiveFile', path: `/tmp/${name}.zip` });
+    const preview = (name) => ({
+        skill: { name },
+        conflict: { kind: 'new' },
+        warnings: [],
+    });
+
+    const firstRun = vm.previewImportInputs(section, [input('first')]);
+    assert.equal(importBusy.value, true);
+    pendingPreviews.get('/tmp/first.zip').resolve(preview('first'));
+    await firstRun;
+    assert.equal(importBusy.value, false);
+
+    await vm.clearImportDraft();
+    const staleSuccessRun = vm.previewImportInputs(section, [input('stale-success')]);
+    await vm.clearImportDraft();
+    const currentRun = vm.previewImportInputs(section, [input('current')]);
+    pendingPreviews.get('/tmp/stale-success.zip').resolve(preview('stale-success'));
+    await staleSuccessRun;
+    assert.equal(vm.importDraft.items[0].input.path, '/tmp/current.zip');
+    assert.equal(vm.importDraft.items[0].preview, null);
+    assert.equal(importBusy.value, true);
+    pendingPreviews.get('/tmp/current.zip').resolve(preview('current'));
+    await currentRun;
+    assert.equal(importBusy.value, false);
+
+    await vm.clearImportDraft();
+    const staleFailureRun = vm.previewImportInputs(section, [input('stale-failure')]);
+    await vm.clearImportDraft();
+    const finalRun = vm.previewImportInputs(section, [input('final')]);
+    pendingPreviews.get('/tmp/stale-failure.zip').reject(new Error('stale failure'));
+    await staleFailureRun;
+    assert.equal(vm.importDraft.items[0].input.path, '/tmp/final.zip');
+    assert.equal(vm.importDraft.items[0].preview, null);
+    pendingPreviews.get('/tmp/final.zip').resolve(preview('final'));
+    await finalRun;
+    assert.equal(importBusy.value, false);
 });
 
 test('Skill Manager previews and installs selected imports sequentially with per-item failure isolation', async (t) => {


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 `https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md` ，并确认此 PR 的目标分支符合贡献指南。

## 变更说明 / Summary

修复了 Skill 管理面板中导入 Skill 后 UI 卡死、按钮变灰无法点击的问题。

**问题现象：** 用户在 UI 上选择新增 Skill 并成功上传后，界面卡住不动，取消按钮变灰无法点击。点击刷新技能按钮后，安装和取消按钮虽然出现但都是灰色不可点击状态。

**根因：** `previewImportInputs` 方法中，先创建普通 JS 对象数组赋值给响应式 data `this.importDraft`，然后在 `for...of` 循环中通过原始数组引用直接修改 `item.preview` 和 `item.error`。在 Vue 3 中，直接修改原始对象的属性不会触发响应式更新，导致 `importBusy` 计算属性永远不会重新求值，始终为 `true`，所有受 `:disabled="importBusy"` 控制的按钮保持禁用状态。

**修复内容：** 将 `for (const item of items)` 改为索引循环，通过 Vue 3 响应式代理 `this.importDraft.items[index]` 来修改 `preview` 和 `error` 属性，确保响应式更新正常触发。

## Vibe Coding / AI 辅助 / AI Assistance

使用 Trae 辅助定位和修复此问题。我审阅了 AI 的完整调试过程：通过阅读 `panel-app.js` 源码理解了 `importBusy` 计算属性和 `previewImportInputs` 方法的数据流，用 Node.js + Vue 3 编写了最小化验证脚本确认了"直接修改原始对象属性不触发响应式更新"这一根因。修复方案将原始引用赋值改为通过 `this.importDraft.items[index]` 代理赋值，我理解这是 Vue 3 响应式系统的正确用法——通过代理修改属性才能被 effect 追踪并触发计算属性重新求值。