### PR TITLE
fix(openai): forward reasoning_effort for custom endpoints #199

### DIFF
--- a/src-tauri/crates/tt-application/src/services/chat_completion_service/payload/openai.rs
+++ b/src-tauri/crates/tt-application/src/services/chat_completion_service/payload/openai.rs
@@ -388,10 +388,10 @@ mod tests {
     }
 
     #[test]
-    fn custom_payload_does_not_forward_reasoning_effort_for_non_openai_models() {
+    fn custom_payload_forwards_reasoning_effort_for_unknown_models() {
         let payload = json!({
             "chat_completion_source": "custom",
-            "model": "claude-opus-4-5",
+            "model": "custom-reasoning-model",
             "messages": [{"role": "user", "content": "hello"}],
             "reasoning_effort": "high",
             "verbosity": "high"
@@ -404,7 +404,12 @@ mod tests {
         assert_eq!(endpoint, "/chat/completions");
 
         let body = upstream.as_object().expect("payload must be object");
-        assert!(body.get("reasoning_effort").is_none());
+
+        assert_eq!(
+            body.get("reasoning_effort").and_then(Value::as_str),
+            Some("high")
+        );
+
         assert!(body.get("verbosity").is_none());
     }
 

--- a/src-tauri/crates/tt-application/src/services/chat_completion_service/payload/openai_reasoning.rs
+++ b/src-tauri/crates/tt-application/src/services/chat_completion_service/payload/openai_reasoning.rs
@@ -39,8 +39,12 @@ const OPENAI_MAX_REASONING_EFFORT_MODELS: &[&str] =
 const OPENAI_XHIGH_REASONING_THRESHOLD: &str = "gpt-5.1-codex-max";
 
 pub(super) fn should_forward_openai_reasoning_effort(source: &str, model: &str) -> bool {
+    if source == "custom" {
+        return true;
+    }
+
     let model = model.trim();
-    matches!(source, "openai" | "custom")
+    source == "openai"
         && (OPENAI_REASONING_EFFORT_MODELS.contains(&model)
             || supports_openai_xhigh_reasoning_effort(model))
 }


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

## 变更说明 / Summary

对于 custom OpenAI-compatible 接口，直接透传 `reasoning_effort`。
