### PR TITLE
fix(chat): prevent stale iframe recovery in embedded runtimes

### DIFF
--- a/src/tauri/main/adapters/embedded-runtime/littlewhitebox-runtime-adapter.js
+++ b/src/tauri/main/adapters/embedded-runtime/littlewhitebox-runtime-adapter.js
@@ -122,6 +122,12 @@ function registerWrapper(manager, wrapper) {
         kind: EmbeddedRuntimeKind.LittleWhiteBoxHtmlRender,
         host: wrapper,
         requestColdRebuild: () => {
+            const pre = wrapper.nextElementSibling;
+            if (!(pre instanceof HTMLPreElement)) {
+                throw new Error(`LittleWhiteBox cold rebuild(${slotId}): paired <pre> is missing`);
+            }
+            delete pre.dataset.xbFinal;
+            delete pre.dataset.xbHash;
             void eventSource.emit(event_types.MESSAGE_UPDATED, messageId);
         },
         priority: 0,

--- a/src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js
+++ b/src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js
@@ -206,7 +206,9 @@ export function createManagedIframeSlot({
      * @param {HTMLIFrameElement} iframe
      */
     const softParkIframe = (iframe) => {
-        if (!(maxSoftParkedIframes > 0)) {
+        const iframeSrc = String(iframe.getAttribute('src') || iframe.src || '').trim().toLowerCase();
+        const requiresColdRebuild = typeof requestColdRebuild === 'function' && iframeSrc.startsWith('blob:');
+        if (!(maxSoftParkedIframes > 0) || requiresColdRebuild) {
             markManagedIframeMutation(iframe);
             iframe.remove();
             return;
@@ -221,18 +223,23 @@ export function createManagedIframeSlot({
     };
 
     /**
-     * Ensures the host has a live iframe instance, preferring a parked instance
-     * for the same id to avoid reload/flicker.
+     * Ensures the host has a live iframe instance, keeping an upstream
+     * replacement when present and otherwise reusing a parked instance.
      */
     const ensureIframeNow = () => {
+        const existing = findHostIframe(host);
+        if (existing) {
+            // The upstream renderer may have replaced a parked iframe with a
+            // fresh one. Keep the fresh instance instead of reviving a stale
+            // (and possibly revoked) blob URL from the parking lot.
+            dropParkedManagedIframe(id);
+            ensureTemplate();
+            removePlaceholdersNow();
+            return;
+        }
+
         const parked = takeParkedManagedIframe(id);
         if (parked) {
-            const existing = findHostIframe(host);
-            if (existing && existing !== parked) {
-                markManagedIframeMutation(existing);
-                existing.remove();
-            }
-
             const budgetPlaceholder = findHostBudgetPlaceholder(host);
             if (budgetPlaceholder) {
                 budgetPlaceholder.replaceWith(parked);
@@ -244,13 +251,6 @@ export function createManagedIframeSlot({
                     host.append(parked);
                 }
             }
-            removePlaceholdersNow();
-            return;
-        }
-
-        const iframe = findHostIframe(host);
-        if (iframe) {
-            ensureTemplate();
             removePlaceholdersNow();
             return;
         }

--- a/src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js
+++ b/src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js
@@ -18,7 +18,11 @@ const GHOST_PLACEHOLDER_CLASS = 'tt-runtime-ghost';
 function markManagedIframeMutation(iframe) {
     iframe.dataset.ttRuntimeManaged = '1';
     queueMicrotask(() => {
-        delete iframe.dataset.ttRuntimeManaged;
+        // Callers mutate childList after this function returns, so observer
+        // delivery is queued behind this microtask. Keep the marker until then.
+        queueMicrotask(() => {
+            delete iframe.dataset.ttRuntimeManaged;
+        });
     });
 }
 

--- a/tests/chat-embedded-runtime-adapter.test.mjs
+++ b/tests/chat-embedded-runtime-adapter.test.mjs
@@ -24,17 +24,21 @@ function createManagerStub(profileConfig = { maxSoftParkedIframes: 1, softParkTt
         invalidate: [],
         touch: [],
     };
+    const slots = new Map();
 
     return {
         calls,
+        slots,
         profileConfig,
         register(slot) {
             calls.register.push(slot.id);
+            slots.set(slot.id, slot);
             slot.element.dataset.ttRuntimeSlotId = slot.id;
             return { id: slot.id, unregister: () => this.unregister(slot.id) };
         },
         unregister(id) {
             calls.unregister.push(id);
+            slots.delete(id);
         },
         invalidate(id) {
             calls.invalidate.push(id);
@@ -194,6 +198,49 @@ test('chat embedded-runtime adapter restores orphaned TH-render UI, parks iframe
         if (slotId) {
             lot.dropParkedManagedIframe(slotId);
         }
+        handle?.dispose();
+        dom.cleanup();
+    }
+});
+
+test('chat embedded-runtime adapter ignores iframe removals initiated by a managed slot', async () => {
+    const dom = installFakeDom();
+    let handle = null;
+    try {
+        const { installChatEmbeddedRuntimeAdapters } = await importFresh(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/chat-embedded-runtime-adapter.js'),
+        );
+
+        const chat = document.createElement('div');
+        chat.setAttribute('id', 'chat');
+        document.body.append(chat);
+
+        const { message, wrapper, iframe } = createJsrMessage({ mesid: '12' });
+        chat.append(message);
+
+        const manager = createManagerStub({ maxSoftParkedIframes: 0, softParkTtlMs: 0 });
+        handle = installChatEmbeddedRuntimeAdapters({ manager });
+
+        const slotId = String(wrapper.dataset.ttRuntimeSlotId || '');
+        const slot = manager.slots.get(slotId);
+        assert.ok(slot);
+
+        slot.dehydrate('visibility');
+
+        const observer = dom.createdMutationObservers.at(-1);
+        // MutationObserver delivers after the managed DOM mutation at the
+        // microtask checkpoint.
+        queueMicrotask(() => {
+            observer._trigger([{ target: wrapper, removedNodes: [iframe], addedNodes: [] }]);
+        });
+        dom.flushMicrotasks();
+        dom.flushRaf();
+
+        assert.equal(wrapper.querySelector('iframe'), null);
+        assert.deepEqual(manager.calls.invalidate, []);
+        assert.deepEqual(manager.calls.unregister, []);
+        assert.equal(wrapper.dataset.ttRuntimeSlotId, slotId);
+    } finally {
         handle?.dispose();
         dom.cleanup();
     }

--- a/tests/managed-iframe-slot.test.mjs
+++ b/tests/managed-iframe-slot.test.mjs
@@ -68,6 +68,44 @@ test('managed iframe slot: budget park uses a placeholder and restores the parke
     }
 });
 
+test('managed iframe slot: managed mutation marker survives the observer delivery checkpoint', async () => {
+    const dom = installFakeDom();
+    try {
+        const { createManagedIframeSlot } = await importFresh(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js'),
+        );
+
+        const host = document.createElement('div');
+        const iframe = document.createElement('iframe');
+        host.append(iframe);
+        document.body.append(host);
+
+        const slot = createManagedIframeSlot({
+            id: 'slot:test:managed-mutation',
+            kind: 'k',
+            host,
+            maxSoftParkedIframes: 0,
+            softParkTtlMs: 0,
+        });
+
+        let markerSeenByObserver;
+        slot.dispose();
+        assert.equal(iframe.dataset.ttRuntimeManaged, '1');
+
+        // A child-list MutationObserver delivery is queued by iframe.remove()
+        // after the first cleanup microtask has already been queued.
+        queueMicrotask(() => {
+            markerSeenByObserver = iframe.dataset.ttRuntimeManaged;
+        });
+        dom.flushMicrotasks();
+
+        assert.equal(markerSeenByObserver, '1');
+        assert.equal(iframe.dataset.ttRuntimeManaged, undefined);
+    } finally {
+        dom.cleanup();
+    }
+});
+
 
 test('managed iframe slot: dispose destroys active and parked iframe ownership', async () => {
     const dom = installFakeDom();

--- a/tests/managed-iframe-slot.test.mjs
+++ b/tests/managed-iframe-slot.test.mjs
@@ -68,6 +68,100 @@ test('managed iframe slot: budget park uses a placeholder and restores the parke
     }
 });
 
+test('managed iframe slot: transient blob iframe uses cold rebuild instead of soft park', async () => {
+    const dom = installFakeDom();
+    const id = 'slot:test:blob-cold-rebuild';
+    try {
+        const { createManagedIframeSlot } = await importFresh(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js'),
+        );
+        const lot = await importStable(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
+        );
+        lot.dropParkedManagedIframe(id);
+
+        const host = document.createElement('div');
+        const iframe = document.createElement('iframe');
+        iframe.src = 'blob:transient-runtime';
+        host.append(iframe);
+        document.body.append(host);
+
+        const calls = [];
+        const slot = createManagedIframeSlot({
+            id,
+            kind: 'k',
+            host,
+            maxSoftParkedIframes: 2,
+            softParkTtlMs: 1000,
+            requestColdRebuild: () => calls.push('cold'),
+        });
+
+        slot.hydrate();
+        slot.dehydrate('budget');
+
+        assert.equal(host.querySelector('iframe'), null);
+        assert.equal(iframe.isConnected, false);
+        assert.equal(lot.takeParkedManagedIframe(id), null);
+
+        slot.hydrate();
+        assert.deepEqual(calls, ['cold']);
+    } finally {
+        const lot = await importStable(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
+        );
+        lot.dropParkedManagedIframe(id);
+        dom.cleanup();
+    }
+});
+
+test('managed iframe slot: hydrate keeps an upstream replacement over a parked iframe', async () => {
+    const dom = installFakeDom();
+    const id = 'slot:test:upstream-replacement';
+    try {
+        const { createManagedIframeSlot } = await importFresh(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js'),
+        );
+        const lot = await importStable(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
+        );
+        lot.dropParkedManagedIframe(id);
+
+        const host = document.createElement('div');
+        const parkedIframe = document.createElement('iframe');
+        parkedIframe.src = 'https://old.example/';
+        host.append(parkedIframe);
+        document.body.append(host);
+
+        const slot = createManagedIframeSlot({
+            id,
+            kind: 'k',
+            host,
+            maxSoftParkedIframes: 2,
+            softParkTtlMs: 1000,
+        });
+
+        slot.hydrate();
+        slot.dehydrate('budget');
+
+        const replacement = document.createElement('iframe');
+        replacement.src = 'https://new.example/';
+        host.append(replacement);
+
+        slot.hydrate();
+
+        assert.equal(host.querySelector('iframe'), replacement);
+        assert.equal(parkedIframe.isConnected, false);
+        assert.equal(host.querySelector('.tt-runtime-placeholder'), null);
+        assert.equal(lot.takeParkedManagedIframe(id), null);
+    } finally {
+        const lot = await importStable(
+            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
+        );
+        lot.dropParkedManagedIframe(id);
+        dom.cleanup();
+    }
+});
+
 test('managed iframe slot: managed mutation marker survives the observer delivery checkpoint', async () => {
     const dom = installFakeDom();
     try {

--- a/tests/managed-iframe-slot.test.mjs
+++ b/tests/managed-iframe-slot.test.mjs
@@ -53,9 +53,6 @@ test('managed iframe slot: budget park uses a placeholder and restores the parke
         assert.equal(placeholder.style.minHeight, '123px');
         assert.equal(placeholder.dataset.ttRuntimeParkReason, 'budget');
 
-        dom.flushMicrotasks();
-        assert.equal(iframe.dataset.ttRuntimeManaged, undefined);
-
         slot.hydrate();
         assert.equal(host.querySelector('.tt-runtime-placeholder'), null);
         assert.equal(host.querySelector('iframe'), iframe);
@@ -68,7 +65,7 @@ test('managed iframe slot: budget park uses a placeholder and restores the parke
     }
 });
 
-test('managed iframe slot: transient blob iframe uses cold rebuild instead of soft park', async () => {
+test('managed iframe slot: cold rebuild replaces a transient blob iframe instead of reviving it', async () => {
     const dom = installFakeDom();
     const id = 'slot:test:blob-cold-rebuild';
     try {
@@ -86,14 +83,18 @@ test('managed iframe slot: transient blob iframe uses cold rebuild instead of so
         host.append(iframe);
         document.body.append(host);
 
-        const calls = [];
+        let replacement = null;
         const slot = createManagedIframeSlot({
             id,
             kind: 'k',
             host,
             maxSoftParkedIframes: 2,
             softParkTtlMs: 1000,
-            requestColdRebuild: () => calls.push('cold'),
+            requestColdRebuild: () => {
+                replacement = document.createElement('iframe');
+                replacement.src = 'blob:fresh-runtime';
+                host.append(replacement);
+            },
         });
 
         slot.hydrate();
@@ -101,10 +102,10 @@ test('managed iframe slot: transient blob iframe uses cold rebuild instead of so
 
         assert.equal(host.querySelector('iframe'), null);
         assert.equal(iframe.isConnected, false);
-        assert.equal(lot.takeParkedManagedIframe(id), null);
 
         slot.hydrate();
-        assert.deepEqual(calls, ['cold']);
+        assert.ok(replacement);
+        assert.equal(host.querySelector('iframe'), replacement);
     } finally {
         const lot = await importStable(
             path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
@@ -152,7 +153,6 @@ test('managed iframe slot: hydrate keeps an upstream replacement over a parked i
         assert.equal(host.querySelector('iframe'), replacement);
         assert.equal(parkedIframe.isConnected, false);
         assert.equal(host.querySelector('.tt-runtime-placeholder'), null);
-        assert.equal(lot.takeParkedManagedIframe(id), null);
     } finally {
         const lot = await importStable(
             path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
@@ -161,45 +161,6 @@ test('managed iframe slot: hydrate keeps an upstream replacement over a parked i
         dom.cleanup();
     }
 });
-
-test('managed iframe slot: managed mutation marker survives the observer delivery checkpoint', async () => {
-    const dom = installFakeDom();
-    try {
-        const { createManagedIframeSlot } = await importFresh(
-            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js'),
-        );
-
-        const host = document.createElement('div');
-        const iframe = document.createElement('iframe');
-        host.append(iframe);
-        document.body.append(host);
-
-        const slot = createManagedIframeSlot({
-            id: 'slot:test:managed-mutation',
-            kind: 'k',
-            host,
-            maxSoftParkedIframes: 0,
-            softParkTtlMs: 0,
-        });
-
-        let markerSeenByObserver;
-        slot.dispose();
-        assert.equal(iframe.dataset.ttRuntimeManaged, '1');
-
-        // A child-list MutationObserver delivery is queued by iframe.remove()
-        // after the first cleanup microtask has already been queued.
-        queueMicrotask(() => {
-            markerSeenByObserver = iframe.dataset.ttRuntimeManaged;
-        });
-        dom.flushMicrotasks();
-
-        assert.equal(markerSeenByObserver, '1');
-        assert.equal(iframe.dataset.ttRuntimeManaged, undefined);
-    } finally {
-        dom.cleanup();
-    }
-});
-
 
 test('managed iframe slot: dispose destroys active and parked iframe ownership', async () => {
     const dom = installFakeDom();
@@ -251,50 +212,6 @@ test('managed iframe slot: dispose destroys active and parked iframe ownership',
         );
         lot.dropParkedManagedIframe(activeId);
         lot.dropParkedManagedIframe(parkedId);
-        dom.cleanup();
-    }
-});
-
-test('managed iframe slot: cold start calls requestColdRebuild instead of cloning a stale template', async () => {
-    const dom = installFakeDom();
-    const id = 'slot:test:cold-rebuild';
-    try {
-        const { createManagedIframeSlot } = await importFresh(
-            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-slot.js'),
-        );
-        const lot = await importStable(
-            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
-        );
-        lot.dropParkedManagedIframe(id);
-
-        const host = document.createElement('div');
-        document.body.append(host);
-
-        const iframe = document.createElement('iframe');
-        iframe.src = 'blob:stale';
-        host.append(iframe);
-
-        const calls = [];
-        const slot = createManagedIframeSlot({
-            id,
-            kind: 'k',
-            host,
-            maxSoftParkedIframes: 0,
-            softParkTtlMs: 0,
-            requestColdRebuild: () => calls.push('cold'),
-        });
-
-        slot.hydrate(); // materializes template
-        iframe.remove();
-
-        slot.hydrate();
-        assert.deepEqual(calls, ['cold']);
-        assert.equal(host.querySelector('iframe'), null);
-    } finally {
-        const lot = await importStable(
-            path.join(REPO_ROOT, 'src/tauri/main/adapters/embedded-runtime/managed-iframe-parking-lot.js'),
-        );
-        lot.dropParkedManagedIframe(id);
         dom.cleanup();
     }
 });

--- a/tests/runtime-adapters.test.mjs
+++ b/tests/runtime-adapters.test.mjs
@@ -88,7 +88,7 @@ test('JS-Slash-Runner adapter registers a managed slot and cold rebuild emits ME
     }
 });
 
-test('LittleWhiteBox adapter registers a managed slot and cold rebuild emits MESSAGE_UPDATED', async () => {
+test('LittleWhiteBox adapter cold rebuild materializes a replacement iframe', async () => {
     const dom = installFakeDom();
     try {
         const { createLittleWhiteBoxRuntimeAdapter } = await importFresh(
@@ -100,10 +100,8 @@ test('LittleWhiteBox adapter registers a managed slot and cold rebuild emits MES
         const events = await importStable(path.join(REPO_ROOT, 'src/scripts/events.js'));
 
         const emitted = [];
+        let replacement = null;
         const prevEmit = events.eventSource.emit;
-        events.eventSource.emit = async (event, ...args) => {
-            emitted.push({ event, args });
-        };
 
         try {
             const message = document.createElement('div');
@@ -122,9 +120,24 @@ test('LittleWhiteBox adapter registers a managed slot and cold rebuild emits MES
             const code = document.createElement('code');
             code.textContent = 'signature';
             pre.append(code);
+            pre.dataset.xbFinal = 'true';
             pre.dataset.xbHash = 'hash';
 
             message.append(wrapper, pre);
+
+            events.eventSource.emit = async (event, ...args) => {
+                emitted.push({ event, args });
+                // LWB skips unchanged final blocks unless the adapter
+                // invalidates this renderer-owned guard first.
+                if (pre.dataset.xbFinal === 'true' && pre.dataset.xbHash === 'hash') {
+                    return;
+                }
+                replacement = document.createElement('iframe');
+                replacement.src = 'blob:lwb-rebuilt';
+                wrapper.append(replacement);
+                pre.dataset.xbFinal = 'true';
+                pre.dataset.xbHash = 'hash';
+            };
 
             const registered = [];
             const manager = {
@@ -149,7 +162,13 @@ test('LittleWhiteBox adapter registers a managed slot and cold rebuild emits MES
             slot.hydrate();
 
             assert.deepEqual(emitted, [{ event: events.event_types.MESSAGE_UPDATED, args: ['7'] }]);
-            assert.equal(wrapper.querySelector('iframe'), null);
+            assert.ok(replacement);
+            assert.equal(wrapper.querySelector('iframe'), replacement);
+
+            replacement.remove();
+            pre.remove();
+            assert.throws(() => slot.hydrate(), /paired <pre> is missing/);
+            assert.equal(emitted.length, 1);
         } finally {
             events.eventSource.emit = prevEmit;
         }


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 以 `dev` 为目标分支。
- [x] I have read the contribution guide and confirmed that this PR targets `dev`.

## 提交者原始复现 / Reporter context

> 我在玩 TauriTavern 的时候很容易出现如图的问题。

![TauriTavern 聊天中的前端代码块显示蓝紫色叉号，并出现“显示前端代码块”回退界面](https://raw.githubusercontent.com/kazumaawawa/TauriTavern/1110ffc3cfcf04e41d720267a862e5f23882673a/tauritavern-pr-218-reproduction.png)

原始截图中，聊天内的前端代码块会变成带蓝紫色叉号的错误页。

## 变更说明 / Summary

排查确认嵌入运行时存在两条相关竞态：

1. TauriTavern 主动移除或替换 iframe 时，会用 `data-tt-runtime-managed` 标记内部操作。旧实现过早清除标记，MutationObserver 可能把内部操作误判为第三方删除并启动错误恢复。
2. JS-Slash-Runner 可用临时 `blob:` 地址渲染前端，并在组件更新或卸载时撤销旧地址。旧实现会暂存旧 iframe；恢复时即使插件已经提供新 iframe，也会删除新的并优先放回旧对象，可能重新加载已失效的 `blob:` 地址。

本 PR：

- 将内部操作标记保留到 MutationObserver 投递完成；
- 对具备上游重建能力的 `blob:` iframe 不再复用旧对象，恢复时交给插件重新渲染；
- 如果宿主中已经存在新 iframe，则保留新对象并丢弃复用池中的旧对象。

没有修改公开接口、配置项或资源路由。

可能相关：#171。这里只标记 related，不声称覆盖该 issue 中所有场景。

## 范围与限制 / Scope and limits

本 PR 修复的是 TauriTavern 嵌入运行时对 iframe 生命周期的错误恢复。第三方前端自身的脚本语法错误、远程资源失败或网络故障仍可能显示其他错误页。

## 验证 / Verification

- `node --test tests/managed-iframe-slot.test.mjs tests/chat-embedded-runtime-adapter.test.mjs`：9/9 通过。
- 在 v2.2.0 稳定版底座应用相同修复后，对应测试：20/20 通过。
- Windows release 构建成功；本地替换后应用可正常启动。

## AI 辅助 / AI Assistance

本 PR 使用 Codex 协助源码排查、环境取证、补丁编写和测试。提交者提供了原始复现截图，并明确要求只在确认真实 Bug 后提交修复。