### PR TITLE
fix(routes, uploads): replace instanceof checks with duck typing for cross-realm extension payloads

### DIFF
--- a/src/tauri/main/routes/character-import-route.js
+++ b/src/tauri/main/routes/character-import-route.js
@@ -1,6 +1,10 @@
 import { assertCharacterAvatarFileName } from '../services/characters/character-identity.js';
 import { badRequestBody, isNotFoundError } from './character-route-utils.js';
 
+const isFormData = (b) => b && typeof b.get === 'function' && typeof b.has === 'function';
+const isBlobLike = (f) => f && typeof f === 'object' && typeof f.arrayBuffer === 'function';
+const isFileLike = (f) => isBlobLike(f) && typeof f.name === 'string';
+
 /**
  * @param {any} character
  * @param {'agentProfiles' | 'skills'} field
@@ -16,12 +20,12 @@ function hasCharacterEmbeddedAgentAsset(character, field) {
 
 export function registerCharacterImportRoute(router, context, { jsonResponse }) {
     router.post('/api/characters/import', async ({ body }) => {
-        if (!(body instanceof FormData)) {
+        if (!isFormData(body)) {
             return jsonResponse({ error: 'Expected multipart form data' }, 400);
         }
 
         const file = body.get('avatar');
-        if (!(file instanceof Blob)) {
+        if (!isBlobLike(file)) {
             return jsonResponse({ error: 'No character file provided' }, 400);
         }
 
@@ -40,7 +44,7 @@ export function registerCharacterImportRoute(router, context, { jsonResponse }) 
 
         const fileType = String(body.get('file_type') || '').trim().toLowerCase();
         const fallbackName = fileType ? `import.${fileType}` : 'import.bin';
-        const preferredName = file instanceof File && file.name ? file.name : fallbackName;
+        const preferredName = isFileLike(file) && file.name ? file.name : fallbackName;
         const fileInfo = await context.materializeUploadFile(file, {
             kind: 'character-import',
             preferredName,
@@ -89,4 +93,4 @@ export function registerCharacterImportRoute(router, context, { jsonResponse }) 
             },
         });
     });
-}
+    }

--- a/src/tauri/main/routes/character-routes.js
+++ b/src/tauri/main/routes/character-routes.js
@@ -9,6 +9,8 @@ import {
 } from './character-route-utils.js';
 import { registerCharacterImportRoute } from './character-import-route.js';
 
+const isFormData = (b) => b && typeof b.get === 'function' && typeof b.has === 'function';
+
 const CHARACTER_CREATE_WARNING_HEADER = 'x-tauritavern-warning';
 
 function hasBodyField(body, fieldName) {
@@ -121,7 +123,7 @@ export function registerCharacterRoutes(router, context, { jsonResponse, textRes
     });
 
     router.post('/api/characters/create', async ({ body, url }) => {
-        if (body instanceof FormData) {
+        if (isFormData(body)) {
             const outcome = await context.createCharacterFromForm(body, url);
             context.invalidateCharacterCache();
             return createCharacterResponse(outcome, textResponse);
@@ -133,7 +135,7 @@ export function registerCharacterRoutes(router, context, { jsonResponse, textRes
     });
 
     router.post('/api/characters/edit', async ({ body, url }) => {
-        if (!(body instanceof FormData)) {
+        if (!isFormData(body)) {
             return jsonResponse({ error: 'Expected multipart form data' }, 400);
         }
 
@@ -195,7 +197,7 @@ export function registerCharacterRoutes(router, context, { jsonResponse, textRes
     });
 
     router.post('/api/characters/edit-avatar', async ({ body, url }) => {
-        if (!(body instanceof FormData)) {
+        if (!isFormData(body)) {
             return jsonResponse({ error: 'Expected multipart form data' }, 400);
         }
 
@@ -394,4 +396,4 @@ export function registerCharacterRoutes(router, context, { jsonResponse, textRes
             },
         });
     });
-}
+            }

--- a/src/tauri/main/services/uploads/upload-service.js
+++ b/src/tauri/main/services/uploads/upload-service.js
@@ -6,6 +6,9 @@
  * @typedef {(command: import('../../context/types.js').TauriInvokeCommand, args?: any, options?: { headers?: HeadersInit }) => Promise<any>} RawInvokeFn
  */
 
+const isBlobLike = (f) => f && typeof f === 'object' && typeof f.arrayBuffer === 'function';
+const isFileLike = (f) => isBlobLike(f) && typeof f.name === 'string';
+
 /**
  * @param {{ safeInvoke?: SafeInvokeFn; invoke?: RawInvokeFn }} [deps]
  */
@@ -226,7 +229,7 @@ export function createUploadService({ safeInvoke, invoke } = {}) {
         const extension = resolveUploadExtension({
             preferredExtension,
             preferredName,
-            sourceName: file instanceof File ? file.name : '',
+            sourceName: isFileLike(file) ? file.name : '',
         });
         let filePath = '';
 
@@ -331,7 +334,7 @@ export function createUploadService({ safeInvoke, invoke } = {}) {
      * @returns {Promise<MaterializedFileInfo | null>}
      */
     async function materializeUploadFile(file, { preferredName = '', preferredExtension = '', kind = DEFAULT_UPLOAD_KIND } = {}) {
-        if (!(file instanceof Blob)) {
+        if (!isBlobLike(file)) {
             return null;
         }
 
@@ -385,4 +388,4 @@ export function createUploadService({ safeInvoke, invoke } = {}) {
         isAndroidRuntime,
         isIosRuntime,
     };
-}
+                }


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

## 变更说明 / Summary

### Problem
When using extensions that execute in separate window/iframe contexts (such as `SillyTavern-CharacterLibrary`), operations like character importing, creating, editing, and avatar updating fail with errors such as `{"error":"Expected multipart form data"}` or `Unable to access uploaded character file path`.

### Root Cause
Objects like `FormData`, `Blob`, and `File` created inside an extension's separate JS realm/iframe do not share prototype chains with the main window's global constructors. Strict checks using `instanceof` (`body instanceof FormData`, `file instanceof Blob`, `file instanceof File`) evaluate to `false` across realm boundaries even though the payloads are valid.

### What Was Changed
Replaced strict `instanceof` checks with duck-typing validation helpers (`isFormData`, `isBlobLike`, `isFileLike`) across three key files:
1. `src/tauri/main/routes/character-import-route.js`: Validates `FormData`, `Blob`, and `File` duck types for `/api/characters/import`.
2. `src/tauri/main/routes/character-routes.js`: Validates `FormData` duck types across `/api/characters/create`, `/edit`, and `/edit-avatar`.
3. `src/tauri/main/services/uploads/upload-service.js`: Replaced `instanceof Blob` and `instanceof File` inside `materializeUploadFile` to allow staging temporary files from cross-realm uploads.

## Vibe Coding / AI 辅助 / AI Assistance

AI assistance was used to analyze the root cause and draft duck-typing snippets. I personally reviewed and verified the changes:
- Recognized the issue as a classic cross-realm JS prototype mismatch where objects passed across window/iframe boundaries fail `instanceof` checks.
- Audited the route and service files to ensure duck-typing methods (`typeof .get === 'function'`, `typeof .arrayBuffer === 'function'`, etc.) safely replace `instanceof` checks without breaking native payload handling or JSON fallback paths.
- Built a custom Canary Android APK (`aarch64-linux-android`) using GitHub Actions and tested it on device. Verified that importing characters via `SillyTavern-CharacterLibrary` now works end-to-end.

---
Closes #219