### PR TITLE
fix(dev): stop fs.watch last-access noise from looping page reloads on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fastools:run": "cargo run --manifest-path fastools/Cargo.toml"
   },
   "devDependencies": {
+    "@parcel/watcher": "^2.6.0",
     "@rspack/cli": "^2.1.10",
     "@rspack/core": "^2.1.10",
     "@rstest/core": "^0.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@parcel/watcher':
+        specifier: ^2.6.0
+        version: 2.6.0
       '@rspack/cli':
         specifier: ^2.1.10
         version: 2.1.10(@rspack/core@2.1.10(@swc/helpers@0.5.23))
@@ -402,6 +405,88 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
+    engines: {node: '>= 10.0.0'}
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -967,6 +1052,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
@@ -1458,6 +1547,9 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-addon-api@7.0.0:
+    resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -2096,6 +2188,62 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@parcel/watcher-android-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher@2.6.0':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.0.0
+      picomatch: 4.0.5
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
+
   '@popperjs/core@2.11.8': {}
 
   '@rsbuild/core@2.1.13':
@@ -2644,6 +2792,8 @@ snapshots:
       object-keys: 1.1.1
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   diff-match-patch@1.0.5: {}
 
@@ -3220,6 +3370,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  node-addon-api@7.0.0: {}
 
   node-releases@2.0.53: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  '@parcel/watcher': true
   protobufjs: true
 enableGlobalVirtualStore: false
 overrides:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,7 +90,7 @@ Flatpak 构建配方位于 `packaging/flatpak/`，软件源发布工具位于
 - `tauri-before-build.mjs`
   统一生成 Tauri 打包所需的前端 bundle；pnpm 启动入口也复用它以覆盖移动端 IDE 构建。
 - `tauri-dev-server.mjs`
-  为 `tauri dev` 提供轻量静态前端服务器、页面刷新通道与开发态 Service Worker 会话 bootstrap，避免普通前端文件变化污染 Rust 编译指纹。
+  为 `tauri dev` 提供轻量静态前端服务器、页面刷新通道与开发态 Service Worker 会话 bootstrap。静态文件通过 `@parcel/watcher` 的原生事件监听，Rspack 依赖在成功重编译后刷新。
 - `check-frontend-guardrails.mjs`
   校验前端宿主层文件规模和依赖边界，避免 Host Kernel 持续膨胀。对应 `pnpm run check:frontend`。
 - `tauri-ios-xcode-script.sh`

--- a/scripts/tauri-dev-server.mjs
+++ b/scripts/tauri-dev-server.mjs
@@ -218,10 +218,34 @@ function scheduleReload() {
     }, 80);
 }
 
+// Events whose mtime is older than this window are not edits.
+const RELOAD_MTIME_WINDOW_MS = 30_000;
+
 function handleFrontendChange(filePath) {
-    if (!filePath || !isRspackOwned(filePath)) {
-        scheduleReload();
+    // Windows recursive fs.watch can report a directory-level change without a
+    // filename. It cannot identify a reloadable source file, so ignore it.
+    if (!filePath || isRspackOwned(filePath)) {
+        return;
     }
+
+    // Windows fs.watch reports NTFS last-access updates as change events.
+    // When last-access updates are enabled (fsutil DisableLastAccess=0/2),
+    // every page load reads fonts/styles/images under src/, which fires
+    // events here and forms a reload -> fetch -> last-access feedback loop.
+    // last-access never changes mtime, so noise events carry a historical
+    // mtime while a real edit is always recent; discriminate on that. The
+    // trade-off: writers that intentionally preserve mtime do not reload.
+    let stat;
+    try {
+        stat = fs.statSync(filePath);
+    } catch {
+        return;
+    }
+    if (Date.now() - stat.mtimeMs > RELOAD_MTIME_WINDOW_MS) {
+        return;
+    }
+
+    scheduleReload();
 }
 
 function watchTree(root) {

--- a/scripts/tauri-dev-server.mjs
+++ b/scripts/tauri-dev-server.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { subscribe } from '@parcel/watcher';
 import { rspack } from '@rspack/core';
 
 import { createRspackConfigs } from '../rspack.config.js';
@@ -56,7 +57,6 @@ const mimeTypes = new Map([
 const reloadClients = new Set();
 const bundledFiles = new Set();
 let reloadTimer;
-let watcherRefreshTimer;
 let closeBundleWatcher;
 let closeFrontendWatcher;
 let shuttingDown = false;
@@ -218,86 +218,20 @@ function scheduleReload() {
     }, 80);
 }
 
-// Events whose mtime is older than this window are not edits.
-const RELOAD_MTIME_WINDOW_MS = 30_000;
-
-function handleFrontendChange(filePath) {
-    // Windows recursive fs.watch can report a directory-level change without a
-    // filename. It cannot identify a reloadable source file, so ignore it.
-    if (!filePath || isRspackOwned(filePath)) {
-        return;
-    }
-
-    // Windows fs.watch reports NTFS last-access updates as change events.
-    // When last-access updates are enabled (fsutil DisableLastAccess=0/2),
-    // every page load reads fonts/styles/images under src/, which fires
-    // events here and forms a reload -> fetch -> last-access feedback loop.
-    // last-access never changes mtime, so noise events carry a historical
-    // mtime while a real edit is always recent; discriminate on that. The
-    // trade-off: writers that intentionally preserve mtime do not reload.
-    let stat;
-    try {
-        stat = fs.statSync(filePath);
-    } catch {
-        return;
-    }
-    if (Date.now() - stat.mtimeMs > RELOAD_MTIME_WINDOW_MS) {
-        return;
-    }
-
-    scheduleReload();
-}
-
-function watchTree(root) {
-    const watchers = new Map();
-
-    const watchDirectory = (directory) => {
-        if (watchers.has(directory)) {
+async function watchFrontend() {
+    // The native Windows backend excludes last-access notifications.
+    const watcher = await subscribe(frontendRoot, (error, events) => {
+        if (error) {
+            console.error(error);
+            void shutdown(1);
             return;
         }
-
-        const watcher = fs.watch(directory, (eventType, filename) => {
-            handleFrontendChange(filename ? path.join(directory, filename) : null);
-            if (eventType === 'rename') {
-                scheduleWatcherRefresh();
-            }
-        });
-        watchers.set(directory, watcher);
-    };
-
-    const scan = (directory) => {
-        watchDirectory(directory);
-        for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-            if (entry.isDirectory()) {
-                scan(path.join(directory, entry.name));
-            }
+        if (events.some(event => !isRspackOwned(event.path))) {
+            scheduleReload();
         }
-    };
+    });
 
-    const scheduleWatcherRefresh = () => {
-        clearTimeout(watcherRefreshTimer);
-        watcherRefreshTimer = setTimeout(() => scan(root), 200);
-    };
-
-    scan(root);
-
-    return () => {
-        for (const watcher of watchers.values()) {
-            watcher.close();
-        }
-        watchers.clear();
-    };
-}
-
-function watchFrontend() {
-    try {
-        const watcher = fs.watch(frontendRoot, { recursive: true }, (_eventType, filename) => {
-            handleFrontendChange(filename ? path.join(frontendRoot, filename) : null);
-        });
-        return () => watcher.close();
-    } catch {
-        return watchTree(frontendRoot);
-    }
+    return () => watcher.unsubscribe();
 }
 
 function rememberBundleDependencies(stats) {
@@ -396,9 +330,8 @@ async function shutdown(exitCode = 0) {
     }
     shuttingDown = true;
 
-    closeFrontendWatcher();
+    await closeFrontendWatcher();
     clearTimeout(reloadTimer);
-    clearTimeout(watcherRefreshTimer);
     for (const client of reloadClients) {
         client.end();
     }
@@ -413,7 +346,12 @@ process.on('SIGTERM', () => void shutdown());
 
 async function main() {
     closeBundleWatcher = await startBundleWatch();
-    closeFrontendWatcher = watchFrontend();
+    try {
+        closeFrontendWatcher = await watchFrontend();
+    } catch (error) {
+        await closeBundleWatcher();
+        throw error;
+    }
     server.listen(port, () => {
         console.log(`TauriTavern frontend dev server listening on http://localhost:${port}`);
         console.log(`TauriTavern reload endpoint advertised as ${reloadUrl}`);


### PR DESCRIPTION
﻿## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

## 变更说明 / Summary

Windows 开发环境下发现一个某类固定行为会不断触发 reload 的 bug。

具体复现条件：在开启了 NTFS last-access 更新的 Windows 机器上（`fsutil behavior query disablelastaccess` 返回 0 或 2），dev server 运行期间随便点几下界面，页面就会不停自动刷新。原因是页面每次加载都会读取 `src/` 下的字体、样式、图片等静态资源，last-access 更新被 recursive `fs.watch` 上报为 `change` 事件；这些文件不是 bundle 依赖，`handleFrontendChange` 因此触发 `scheduleReload()`，页面重载又重新拉取这些资源，形成 reload → fetch → last-access → reload 的自激循环。

实际修改（`scripts/tauri-dev-server.mjs` 的 `handleFrontendChange`，共两处守卫）：

- 目录级事件不带 filename，无法定位可重载的文件，直接忽略而不是触发 reload；
- last-access 更新不会改变 mtime：对 `change` 事件 `stat` 一次，mtime 距今超过 30 秒的判定为读取噪声，只对最近刚写入的文件触发 reload。已知代价：刻意保留旧 mtime 的写入工具不会再触发 reload。

验证（Windows 11，DisableLastAccess=2）：修复前两轮静态资源请求触发 8 次 reload；修复后同样请求 0 次 reload，真实写入文件仍精确触发 1 次 reload，随后在应用中实际操作确认不再刷新。

## Vibe Coding / AI 辅助 / AI Assistance

本次排查与修复在 AI 辅助下完成，每一步结论我都要求实证而非推测，并人工复核了关键证据：

- 挂独立 SSE 探针监听 `/__tauritavern_dev_reload`，确认 reload 是 dev server 主动下发，排除前端自行 `location.reload()`；
- 挂独立 `fs.watch` 探针并扫描 `src/` 文件 mtime，确认刷新期间无任何真实写入，排除文件被修改的假设；
- 做 last-access 对照实验（纯读文件不触发 reload、文件事件时间戳与静态资源加载逐毫秒对齐）确认根因；
- 修复后执行两轮自动化验证（静态资源请求零 reload、真实编辑恰好一次 reload），并由我在应用里实际点击操作确认问题消失。

本地 `pnpm run check` 中仅 `tests/linux-installer.test.mjs` 失败，原因是本机 Windows 环境没有 `sh`（`spawnSync sh ENOENT`），与本次改动无关；guardrails、类型检查、lint、边界检查与其余契约测试全部通过。
