### PR TITLE
feat(opencode): per-chat session id derivation and unsaved-chat coverage

### DIFF
--- a/src-tauri/crates/tt-application/src/services/chat_completion_service/mod.rs
+++ b/src-tauri/crates/tt-application/src/services/chat_completion_service/mod.rs
@@ -48,6 +48,10 @@ use self::stream_session::{StreamAppendOutcome, StreamSessionRegistry};
 const OPENAI_SOURCE: &str = ChatCompletionSource::OpenAi.key();
 pub(crate) const OPENCODE_STABLE_CHAT_ID_FIELD: &str = "_tauritavern_stable_chat_id";
 const OPENCODE_SESSION_HEADER: &str = "x-opencode-session";
+/// 会话命名空间：内部聊天身份只做派生输入，不原文暴露给第三方；
+/// 同一聊天恒得同一会话，不同聊天恒不同（见 derive_opencode_session_id）。
+const OPENCODE_SESSION_ID_DOMAIN: &str = "tt-opencode-session-v1";
+const OPENCODE_SESSION_ID_PREFIX: &str = "tt-oc-";
 const VERTEXAI_PROMPT_CACHE_SESSION_HEADER: &str = "X-Vertex-Ai-Session-Id";
 const AGENT_STRUCTURAL_BODY_OVERRIDE_KEYS: &[&str] = &[
     "messages",
@@ -927,6 +931,14 @@ fn has_configured_header(config: &ChatCompletionApiConfig, header_name: &str) ->
         .any(|key| key.eq_ignore_ascii_case(header_name))
 }
 
+/// 每个聊天独立的会话 token：派生自稳定聊天身份（vertexai 的 tt-pc- 同款做法），
+/// 内部身份不原文出境；相同输入恒得相同输出，无持久化需求。
+fn derive_opencode_session_id(stable_chat_id: &str) -> String {
+    let digest_input = format!("{OPENCODE_SESSION_ID_DOMAIN}:{stable_chat_id}");
+    let digest = Sha256::digest(digest_input.as_bytes());
+    format!("{OPENCODE_SESSION_ID_PREFIX}{}", &hex_lower(&digest)[..32])
+}
+
 fn apply_opencode_session_header(
     source: ChatCompletionSource,
     payload: &Map<String, Value>,
@@ -950,7 +962,7 @@ fn apply_opencode_session_header(
         })?;
     config.extra_headers.insert(
         OPENCODE_SESSION_HEADER.to_string(),
-        stable_chat_id.to_string(),
+        derive_opencode_session_id(stable_chat_id),
     );
     Ok(())
 }
@@ -1002,7 +1014,8 @@ mod tests {
     use super::{
         AdditionalParameters, ChatCompletionService, apply_nanogpt_claude_cache_control,
         apply_opencode_session_header, apply_vertexai_prompt_cache_session_header,
-        ensure_vertexai_claude_prompt_cache_ttl, resolve_status_model_list_source,
+        derive_opencode_session_id, ensure_vertexai_claude_prompt_cache_ttl,
+        resolve_status_model_list_source,
     };
     use crate::errors::ApplicationError;
     use tokio::sync::watch;
@@ -1105,13 +1118,85 @@ mod tests {
         )
         .unwrap();
 
+        // 头值是派生会话 token，不再原文回显内部聊天身份（金色值 pin 住派生算法）
         assert_eq!(
             config
                 .extra_headers
                 .get("x-opencode-session")
                 .map(String::as_str),
-            Some("stable-chat")
+            Some("tt-oc-4581999545c841e20ce4536943fe8339")
         );
+        assert_eq!(
+            derive_opencode_session_id("stable-chat"),
+            "tt-oc-4581999545c841e20ce4536943fe8339"
+        );
+    }
+
+    #[test]
+    fn opencode_session_header_edge_cases() {
+        let mut config = ChatCompletionApiConfig {
+            base_url: "https://opencode.ai/zen/v1".to_string(),
+            user_configured_endpoint: false,
+            api_key: "secret".to_string(),
+            authorization_header: None,
+            vertexai_service_account_json: None,
+            extra_headers: Default::default(),
+            additional_headers: Default::default(),
+            anthropic_beta_header_mode: AnthropicBetaHeaderMode::None,
+            aws_bedrock_custom_response_path: None,
+            aws_bedrock_custom_stream_path: None,
+        };
+        // 空白身份仍拒绝（fail-fast intact）
+        let blank_id = json!({ "_tauritavern_stable_chat_id": "   " });
+        assert!(
+            apply_opencode_session_header(
+                ChatCompletionSource::OpenCode,
+                blank_id.as_object().unwrap(),
+                &mut config,
+            )
+            .is_err()
+        );
+        // 非 opencode 渠道不写头
+        let payload = json!({ "_tauritavern_stable_chat_id": "stable-chat" });
+        apply_opencode_session_header(
+            ChatCompletionSource::OpenAi,
+            payload.as_object().unwrap(),
+            &mut config,
+        )
+        .unwrap();
+        assert!(!config.extra_headers.contains_key("x-opencode-session"));
+        // 用户预置头优先，不覆盖
+        config
+            .additional_headers
+            .insert("X-OpenCode-Session".to_string(), "user-pinned".to_string());
+        apply_opencode_session_header(
+            ChatCompletionSource::OpenCode,
+            payload.as_object().unwrap(),
+            &mut config,
+        )
+        .unwrap();
+        assert_eq!(
+            config
+                .extra_headers
+                .get("x-opencode-session")
+                .map(String::as_str),
+            None
+        );
+    }
+
+    #[test]
+    fn opencode_session_id_is_stable_per_chat_and_independent_across_chats() {
+        let first = derive_opencode_session_id("stable-chat");
+        assert_eq!(first, derive_opencode_session_id("stable-chat"));
+        assert!(first.starts_with("tt-oc-"));
+        assert_eq!(first.len(), "tt-oc-".len() + 32);
+        assert!(
+            first["tt-oc-".len()..]
+                .chars()
+                .all(|c| c.is_ascii_hexdigit())
+        );
+        assert!(!first.contains("stable-chat"));
+        assert_ne!(first, derive_opencode_session_id("another-chat"));
     }
 
     #[test]

--- a/src/tauri/main/routes/ai-routes.js
+++ b/src/tauri/main/routes/ai-routes.js
@@ -226,7 +226,58 @@ async function attachOpenCodeStableChatId(payload) {
         return;
     }
 
-    payload[OPENCODE_STABLE_CHAT_ID_FIELD] = await globalThis.__TAURITAVERN__.api.chat.current.handle().stableId();
+    payload[OPENCODE_STABLE_CHAT_ID_FIELD] = await resolveOpenCodeChatId();
+}
+
+// 未保存的新聊天没有 integrity：给它一个本页生命周期内稳定的临时身份，
+// 请求能发出去（冷缓存），存盘后 integrity 出现即自动切到稳定身份（一次会话切换）。
+// key 取当前聊天引用而非句柄：同一未保存聊天多次生成复用同一临时身份。
+const opencodeEphemeralChatIds = new Map();
+
+function getOpenCodeEphemeralChatKey() {
+    try {
+        const ref = globalThis.__TAURITAVERN__?.api?.chat?.current?.ref?.();
+        if (!ref || typeof ref !== 'object') {
+            return null;
+        }
+        if (ref.kind === 'character') {
+            // 空字段不组 key：不同非法引用共用 'character::' 会串临时身份，退回不缓存
+            if (!ref.characterId || !ref.fileName) {
+                return null;
+            }
+            return `character:${ref.characterId}:${ref.fileName}`;
+        }
+        if (ref.kind === 'group') {
+            if (!ref.chatId) {
+                return null;
+            }
+            return `group:${ref.chatId}`;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function resolveOpenCodeChatId() {
+    try {
+        const stable = String(await globalThis.__TAURITAVERN__.api.chat.current.handle().stableId() ?? '').trim();
+        if (stable) {
+            return stable;
+        }
+    } catch {
+        // integrity 缺失的新聊天：下面走临时身份，不抛错阻断生成
+    }
+
+    const key = getOpenCodeEphemeralChatKey();
+    if (key && opencodeEphemeralChatIds.has(key)) {
+        return opencodeEphemeralChatIds.get(key);
+    }
+    const ephemeral = `ephemeral-${createStreamId()}`;
+    if (key) {
+        opencodeEphemeralChatIds.set(key, ephemeral);
+    }
+    return ephemeral;
 }
 
 function buildErrorAssistantText(error) {

--- a/tests/secret-id-contract.test.mjs
+++ b/tests/secret-id-contract.test.mjs
@@ -116,3 +116,160 @@ test('OpenCode generation carries the current stable chat id', async () => {
     const generate = calls.find(call => call.command === 'generate_chat_completion');
     assert.equal(generate.args.dto._tauritavern_stable_chat_id, 'stable-chat');
 });
+
+test('OpenCode generation falls back to a stable ephemeral id for unsaved chats', async () => {
+    const ref = { kind: 'character', characterId: 'Alice', fileName: 'unsaved-chat' };
+    globalThis.__TAURITAVERN__ = {
+        api: {
+            chat: {
+                current: {
+                    ref: () => ref,
+                    handle: () => ({
+                        stableId: async () => {
+                            throw new Error('Chat metadata integrity is missing');
+                        },
+                    }),
+                },
+            },
+        },
+    };
+    const calls = [];
+    const router = await createAiRouter(async (command, args) => {
+        calls.push({ command, args });
+        return {};
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+        await router.handle({
+            method: 'POST',
+            path: '/api/backends/chat-completions/generate',
+            body: { chat_completion_source: 'opencode', type: 'quiet' },
+        });
+    }
+
+    const ids = calls
+        .filter(call => call.command === 'generate_chat_completion')
+        .map(call => call.args.dto._tauritavern_stable_chat_id);
+    assert.equal(ids.length, 2);
+    assert.match(ids[0], /^ephemeral-/);
+    assert.equal(ids[1], ids[0]);
+});
+
+test('OpenCode ephemeral ids are independent per unsaved chat', async () => {
+    let currentRef = { kind: 'character', characterId: 'Alice', fileName: 'unsaved-one' };
+    globalThis.__TAURITAVERN__ = {
+        api: {
+            chat: {
+                current: {
+                    ref: () => currentRef,
+                    handle: () => ({
+                        stableId: async () => {
+                            throw new Error('Chat metadata integrity is missing');
+                        },
+                    }),
+                },
+            },
+        },
+    };
+    const calls = [];
+    const router = await createAiRouter(async (command, args) => {
+        calls.push({ command, args });
+        return {};
+    });
+
+    await router.handle({
+        method: 'POST',
+        path: '/api/backends/chat-completions/generate',
+        body: { chat_completion_source: 'opencode', type: 'quiet' },
+    });
+    currentRef = { kind: 'character', characterId: 'Bob', fileName: 'unsaved-two' };
+    await router.handle({
+        method: 'POST',
+        path: '/api/backends/chat-completions/generate',
+        body: { chat_completion_source: 'opencode', type: 'quiet' },
+    });
+
+    const ids = calls
+        .filter(call => call.command === 'generate_chat_completion')
+        .map(call => call.args.dto._tauritavern_stable_chat_id);
+    assert.equal(ids.length, 2);
+    assert.match(ids[0], /^ephemeral-/);
+    assert.match(ids[1], /^ephemeral-/);
+    assert.notEqual(ids[0], ids[1]);
+});
+
+test('OpenCode falls back to an uncached ephemeral id when the chat ref is missing', async () => {
+    globalThis.__TAURITAVERN__ = {
+        api: {
+            chat: {
+                current: {
+                    handle: () => ({
+                        stableId: async () => {
+                            throw new Error('Chat metadata integrity is missing');
+                        },
+                    }),
+                },
+            },
+        },
+    };
+    const calls = [];
+    const router = await createAiRouter(async (command, args) => {
+        calls.push({ command, args });
+        return {};
+    });
+
+    await router.handle({
+        method: 'POST',
+        path: '/api/backends/chat-completions/generate',
+        body: { chat_completion_source: 'opencode', type: 'quiet' },
+    });
+
+    const generate = calls.find(call => call.command === 'generate_chat_completion');
+    assert.match(generate.args.dto._tauritavern_stable_chat_id, /^ephemeral-/);
+});
+
+test('OpenCode switches to the stable id once the chat is saved', async () => {
+    let saved = false;
+    const ref = { kind: 'character', characterId: 'Alice', fileName: 'new-chat' };
+    globalThis.__TAURITAVERN__ = {
+        api: {
+            chat: {
+                current: {
+                    ref: () => ref,
+                    handle: () => ({
+                        stableId: async () => {
+                            if (!saved) {
+                                throw new Error('Chat metadata integrity is missing');
+                            }
+                            return 'stable-after-save';
+                        },
+                    }),
+                },
+            },
+        },
+    };
+    const calls = [];
+    const router = await createAiRouter(async (command, args) => {
+        calls.push({ command, args });
+        return {};
+    });
+
+    await router.handle({
+        method: 'POST',
+        path: '/api/backends/chat-completions/generate',
+        body: { chat_completion_source: 'opencode', type: 'quiet' },
+    });
+    saved = true;
+    await router.handle({
+        method: 'POST',
+        path: '/api/backends/chat-completions/generate',
+        body: { chat_completion_source: 'opencode', type: 'quiet' },
+    });
+
+    const ids = calls
+        .filter(call => call.command === 'generate_chat_completion')
+        .map(call => call.args.dto._tauritavern_stable_chat_id);
+    assert.equal(ids.length, 2);
+    assert.match(ids[0], /^ephemeral-/);
+    assert.equal(ids[1], 'stable-after-save');
+});


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

## 变更说明 / Summary

opencode 供应商的 `x-opencode-session` 原来原文回显内部稳定聊天身份（`integrity` / `chatId`），且新未保存聊天没有 integrity，请求在前端直接抛错发不出去。这个 PR 让每个聊天都有独立会话：

- 后端将会话值改为派生 token（`tt-oc-` + sha256 命名空间哈希前 32 hex，vertexai 的 `tt-pc-` 同款做法）：同一聊天恒得同一会话，不同聊天恒不同，内部身份不再原文出境；用户预置头仍优先，缺身份仍报错（fail-fast 不变）。
- 前端给无 integrity 的新聊天一个本页生命周期内稳定的临时身份（按聊天引用缓存的 `ephemeral-<uuid>`），请求能发出去（冷缓存），存盘后自动切到稳定身份。
- 模型切换不纳入会话划分（酒馆侧切模型不常见，刻意不管）。

改动：`chat_completion_service/mod.rs`（派生函数 + 单测）、`ai-routes.js`（临时身份回退）、`secret-id-contract.test.mjs`（4 个新用例）。

验证：`cargo test -p tt-application` 520 全过；`secret-id-contract` 7/7；`cargo clippy` 无警告；`cargo fmt --check` 通过；contracts 全套的失败项在干净 dev 上同样失败（环境依赖，与本改动无关）；另有两路子代理做唯读审查，意见（金色值 pin 定、空字段 key 守卫等）已落实。

## Vibe Coding / AI 辅助 / AI Assistance

纯muse spark vibe coding。

If Vibe Coding, Codex, Claude Code, Copilot, ChatGPT, or another AI-assisted tool was used, please explain in your own words how you reviewed and understood the changes.
