### PR TITLE
ci: post branch guidance before closing pull requests

### DIFF
--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -21,14 +21,14 @@ jobs:
             const pull_number = context.payload.pull_request.number;
             const guide = `https://github.com/${owner}/${repo}/blob/dev/CONTRIBUTING.md`;
 
-            await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });
-
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: pull_number,
               body: [
-                `感谢您对 TauriTavern 的贡献！本项目的常规 PR 请提交到 \`dev\` 分支。由于此 PR 的目标分支不是 \`dev\`，机器人已将其关闭。请阅读 [贡献指南](${guide})，将目标分支改为 \`dev\` 后重新打开。如果这是必须直接提交到 \`main\` 的紧急修复，请说明原因并重新打开此 PR。`,
-                `Thank you for contributing to TauriTavern! Regular PRs should target \`dev\`. This PR has been automatically closed because it targets another branch. Please read [CONTRIBUTING.md](${guide}), change the target branch to \`dev\`, and reopen the PR. If this is an urgent fix that must go directly to \`main\`, please explain why and reopen this PR.`,
+                `感谢您对 TauriTavern 的贡献！本项目的常规 PR 请提交到 \`dev\` 分支。由于此 PR 的目标分支不是 \`dev\`，机器人将自动关闭此 PR。请阅读 [贡献指南](${guide})，将目标分支改为 \`dev\` 后重新打开。如果这是必须直接提交到 \`main\` 的紧急修复，请说明原因并重新打开此 PR。`,
+                `Thank you for contributing to TauriTavern! Regular PRs should target \`dev\`. This PR will be automatically closed because it targets another branch. Please read [CONTRIBUTING.md](${guide}), change the target branch to \`dev\`, and reopen the PR. If this is an urgent fix that must go directly to \`main\`, please explain why and reopen this PR.`,
               ].join('\n\n'),
             });
+
+            await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });


### PR DESCRIPTION
Post the bilingual contribution guidance before closing a PR. If posting the comment fails, the PR remains open. Update both messages to say the PR will be closed.

This targets `main` to update the active workflow on the default branch. The same change is included on `dev`.

Validation: YAML parsing, successful comment-before-close ordering, and comment-failure behavior passed. `pnpm run check` passed.
