### PR TITLE
fix(frontend): defer SlashCommandParser construction to break TDZ on …

### DIFF
--- a/src/scripts/slash-commands.js
+++ b/src/scripts/slash-commands.js
@@ -115,12 +115,39 @@ export {
     executeSlashCommands, executeSlashCommandsWithOptions, getSlashCommandsHelp, registerSlashCommand,
 };
 
-export const parser = new SlashCommandParser();
+// Constructed on first use instead of at module-evaluation time. The constructor
+// calls SlashCommand.fromProps(), and this module sits inside the cycle
+// slash-commands.js -> SlashCommandParser.js -> SlashCommand.js ->
+// SlashCommandArgument.js -> SlashCommandCommonEnumsProvider.js ->
+// extensions.js -> st-context.js -> slash-commands.js. Depending on which module
+// the evaluator enters first, SlashCommand can still be in its temporal dead zone
+// when that constructor runs.
+let _parserInstance = null;
+function getParserInstance() {
+    return _parserInstance ??= new SlashCommandParser();
+}
+// Every trap resolves through getParserInstance(): parse() assigns
+// this.closureIndex/commandIndex/scopeIndex/macroIndex and reads them back in the
+// same call, so a get-only proxy would drop those writes and every parser.parse()
+// would fail with "Cannot read properties of undefined (reading 'push')".
+// isExtensible/preventExtensions stay untrapped to keep the proxy invariants
+// intact for the empty target.
+const parser = new Proxy(Object.create(null), {
+    get: (_target, prop) => Reflect.get(getParserInstance(), prop),
+    set: (_target, prop, value) => Reflect.set(getParserInstance(), prop, value),
+    has: (_target, prop) => Reflect.has(getParserInstance(), prop),
+    deleteProperty: (_target, prop) => Reflect.deleteProperty(getParserInstance(), prop),
+    defineProperty: (_target, prop, descriptor) => Reflect.defineProperty(getParserInstance(), prop, descriptor),
+    getOwnPropertyDescriptor: (_target, prop) => Reflect.getOwnPropertyDescriptor(getParserInstance(), prop),
+    ownKeys: () => Reflect.ownKeys(getParserInstance()),
+    getPrototypeOf: () => Reflect.getPrototypeOf(getParserInstance()),
+});
+export { parser };
 /**
  * @deprecated Use SlashCommandParser.addCommandObject() instead
  */
 const registerSlashCommand = SlashCommandParser.addCommand.bind(SlashCommandParser);
-const getSlashCommandsHelp = parser.getHelpString.bind(parser);
+const getSlashCommandsHelp = () => getParserInstance().getHelpString();
 
 /**
  * Converts a SlashCommandClosure to a filter function that returns a boolean.


### PR DESCRIPTION
## 提交前确认 / Before Opening

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md)，并确认此 PR 的目标分支符合贡献指南。
- [x] I have read [CONTRIBUTING.md](https://github.com/Darkatse/TauriTavern/blob/dev/CONTRIBUTING.md) and confirmed that this PR targets the appropriate branch.

（目标分支：`dev`）

## 变更说明 / Summary

### 现象

启动时黑屏。PC 端偶然出现，安卓端出现频率较高（复现设备：小米 13 Pro）。**该问题无法 100% 稳定复现**，推测与设备 / 模块求值顺序有关。

崩溃时为：

```
ReferenceError: Cannot access 'SlashCommand' before initialization
    at new SlashCommandParser (src/scripts/slash-commands/SlashCommandParser.js:149)
    at src/scripts/slash-commands.js:118
```

### 根因

`slash-commands.js` 顶层的 `export const parser = new SlashCommandParser();` 在**模块求值期**就把解析器构造出来，而 `SlashCommandParser` 的构造函数会调用 `SlashCommand.fromProps()`。这个模块正处在一条环里（每条边都已逐一核对）：

```
slash-commands.js:74
  -> SlashCommandParser.js:3   -> SlashCommand.js:4
  -> SlashCommandArgument.js:2 -> SlashCommandCommonEnumsProvider.js:2
  -> extensions.js:7           -> st-context.js:96
  -> slash-commands.js         (闭环)
```

求值器先进入哪个模块会随入口、打包结果和运行时而变化。一旦走到"`SlashCommand.js` 尚未求值完、`slash-commands.js` 顶层已开始执行"这种顺序，`SlashCommand` 就还在 TDZ。这解释了为什么两端都可能触发、安卓概率更高、且无法稳定复现。

### 改法

- `parser` 改为惰性代理，**首次访问时才构造**，此时模块求值早已结束，TDZ 触发路径被物理消除。
- 所有 trap 都转发到真实实例（`get/set/has/deleteProperty/defineProperty/getOwnPropertyDescriptor/ownKeys/getPrototypeOf`）。这是必需的：`parse()` 会在同一次调用里写 `this.closureIndex` / `commandIndex` / `scopeIndex` / `macroIndex` 再立刻读回，只转发 `get` 的代理会把这些写入丢进空 target，导致**所有** `parser.parse()` 报 `Cannot read properties of undefined (reading 'push')`（斜杠命令、快捷回复全线失效）。
- 故意**不** trap `isExtensible` / `preventExtensions`：target 是空的普通对象，如实转发真实实例的扩展性会违反 Proxy invariant。
- `getSlashCommandsHelp` 不再在模块顶层 `parser.getHelpString.bind(parser)`，否则模块求值期又会触发构造。
- **没有**在 `SlashCommandParser` 构造函数里预置那 4 个索引数组：`parse()` 是它们唯一且无条件的赋值点，预置只会掩盖"写入被吞"的症状，属于替系统猜结果（CONTRIBUTING 原则 3）。

### 关于测试

没有新增自动化测试。最高行为边界是 `parser.parse()`，但它在打包器之外加载不了：`slash-commands.js` 的依赖链会走到 `src/scripts/macros/engine/MacroDiagnostics.js`，后者用根绝对路径 `import ... from '/scripts/i18n.js'`，node 直接加载报 `Cannot find module '...\scripts\i18n.js'`；`pnpm test:contracts` 是纯 `node --test`（无别名、无 DOM），`rstest.config.mjs` 又只 include agent-system、mcp-manager、tauri/setting 三个目录。为"能测"而把实现改造成可测，会引入只为测试存在的抽象，不符合 KISS 与测试准入条款，因此改为手工验证：

- Android WebView 冷启动不再出现 `Cannot access 'SlashCommand' before initialization`；
- 斜杠命令、带闭包的快捷回复能正常解析并执行（这是写入被吞时最先挂掉的路径）。

已跑：`pnpm test:contracts`（441 passed / 1 skipped）、`pnpm check:lint`、`pnpm check:frontend`、`pnpm check:startup`、`pnpm check:types`。

### 兼容性

`export { parser }` 的对外形状不变（行为上仍是 `SlashCommandParser` 实例），第三方扩展若从 `slash-commands.js` 导入 `parser` 无需改动。

### English summary

`slash-commands.js` constructed `SlashCommandParser` during module evaluation, while the module sits inside the import cycle `slash-commands.js -> SlashCommandParser.js -> SlashCommand.js -> SlashCommandArgument.js -> SlashCommandCommonEnumsProvider.js -> extensions.js -> st-context.js -> slash-commands.js`. Depending on evaluation order, `SlashCommand` is still in its temporal dead zone and startup dies with `ReferenceError: Cannot access 'SlashCommand' before initialization`. It reproduces intermittently on desktop and more often on Android (Xiaomi 13 Pro), and cannot be reproduced deterministically.

`parser` is now a lazy proxy built on first use, after module evaluation. Every trap forwards to the real instance, because `parse()` assigns `this.closureIndex/commandIndex/scopeIndex/macroIndex` and reads them back in the same call — a get-only proxy drops those writes and every `parser.parse()` fails with `Cannot read properties of undefined (reading 'push')`. `isExtensible`/`preventExtensions` stay untrapped to keep the proxy invariants intact. `getSlashCommandsHelp` no longer binds at module scope. The constructor is not pre-seeded with empty index arrays: `parse()` is their only assignment site.

No automated test: the highest behavior boundary is `parser.parse()`, which cannot be loaded outside the bundler (the dependency chain reaches `macros/engine/MacroDiagnostics.js`, importing `/scripts/i18n.js` by absolute root path; `test:contracts` is plain `node --test`; rstest only covers three directories). Verified manually instead.

## Vibe Coding / AI 辅助 / AI Assistance

- 启动时黑屏，我在 PC 端偶然出现这个问题，安卓端频率较高，设备是小米 13 Pro，但是这个问题无法百分之百稳定复现，可能和设备有关系。
- 实际修改 `src/scripts/slash-commands.js`。
- 加了一个 proxy 防止 TDZ 现象。
- 我自己测试的情况是修复之后不会再出现该问题